### PR TITLE
feat(UBottomSheet): Build bottomSheets with two button and for pin page - FA-35

### DIFF
--- a/packages/ui_library/lib/core/const/u_sizes.dart
+++ b/packages/ui_library/lib/core/const/u_sizes.dart
@@ -63,4 +63,10 @@ class USizes {
   static const double recoverySeedBoxHeightSize = 40.0;
   static const double recoverySeedBoxNumberBoxWidthSize = 14.0;
   static const double recoverySeedBoxNumberBoxHeightSize = 15.0;
+
+  // Sizes for [UBottomSheet]
+  static const double barAboveBottomSheetHeightSize = 2.0;
+  static const double barAboveBottomSheetWidthSize = 72.0;
+  static const double barAboveBottomSheetBorderRadius = 8.0;
+  static const double bottomSheetTemplateBorderRadius = 20.0;
 }

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_export.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_export.dart
@@ -1,0 +1,1 @@
+export 'u_bottom_sheet_two_buttons.dart';

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_export.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_export.dart
@@ -1,1 +1,2 @@
 export 'u_bottom_sheet_two_buttons.dart';
+export 'u_bottom_sheet_pin.dart';

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/core/core_export.dart';
+
+class UBottomSheet {
+  final BuildContext context;
+
+  final Widget child;
+
+  UBottomSheet(
+    this.context,
+    this.child,
+  );
+  Future show() {
+    return showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        isDismissible: true,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+        ),
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.width > 500
+              ? MediaQuery.of(context).size.width
+              : 500,
+        ),
+        builder: (context) {
+          return Stack(
+            children: [
+              Container(
+                margin: const EdgeInsets.only(bottom: 4),
+                decoration: const BoxDecoration(
+                  color: UColors.textDark,
+                  borderRadius: BorderRadius.all(
+                    Radius.circular(5),
+                  ),
+                ),
+                height: 2,
+                width: 72,
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
+                child: child,
+              ),
+            ],
+          );
+        });
+  }
+}
+
+// class _BottomSheetBackground extends StatelessWidget {
+//   const _BottomSheetBackground({
+//     Key? key,
+//   }) : super(key: key);
+
+//   @override
+//   Widget build(BuildContext context) => Column(
+//         mainAxisAlignment: MainAxisAlignment.center,
+//         mainAxisSize: MainAxisSize.max,
+//         children: [
+//           Container(
+//             margin: EdgeInsets.only(bottom: MoonSpacerSize.xxxs.kSize),
+//             decoration: const BoxDecoration(
+//               color: Colors.white,
+//               borderRadius: BorderRadius.all(
+//                 Radius.circular(5),
+//               ),
+//             ),
+//             height: 4,
+//             width: 64,
+//           ),
+//           Expanded(
+//             child: Container(
+//               decoration: BoxDecoration(
+//                 color: MoonContantsColors.secondaryDark,
+//                 borderRadius: BorderRadius.only(
+//                   topLeft: Radius.circular(MoonSpacerSize.xxs.kSize),
+//                   topRight: Radius.circular(MoonSpacerSize.xxs.kSize),
+//                 ),
+//               ),
+//             ),
+//           ),
+//           Expanded(
+//             child: Container(
+//               decoration: const BoxDecoration(
+//                 color: MoonContantsColors.secondaryDarker,
+//               ),
+//             ),
+//           ),
+//         ],
+//       );
+// }}

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
@@ -7,9 +7,9 @@ class UBottomSheet {
   final Widget child;
 
   UBottomSheet(
-    this.context,
-    this.child,
-  );
+    this.context, {
+    required this.child,
+  });
   Future show() {
     return showModalBottomSheet(
         context: context,
@@ -22,27 +22,30 @@ class UBottomSheet {
             topRight: Radius.circular(20),
           ),
         ),
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.width > 500
-              ? MediaQuery.of(context).size.width
-              : 500,
-        ),
         builder: (context) {
-          return Stack(
+          return Wrap(
             children: [
+              Center(
+                child: Container(
+                  margin: const EdgeInsets.only(bottom: 9),
+                  decoration: const BoxDecoration(
+                    color: UColors.textDark,
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(5),
+                    ),
+                  ),
+                  height: 2,
+                  width: 72,
+                ),
+              ),
               Container(
-                margin: const EdgeInsets.only(bottom: 4),
                 decoration: const BoxDecoration(
-                  color: UColors.textDark,
-                  borderRadius: BorderRadius.all(
-                    Radius.circular(5),
+                  color: UColors.modalDark,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(20),
+                    topRight: Radius.circular(20),
                   ),
                 ),
-                height: 2,
-                width: 72,
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
                 child: child,
               ),
             ],
@@ -51,45 +54,45 @@ class UBottomSheet {
   }
 }
 
-// class _BottomSheetBackground extends StatelessWidget {
-//   const _BottomSheetBackground({
-//     Key? key,
-//   }) : super(key: key);
+class _BottomSheetBackground extends StatelessWidget {
+  const _BottomSheetBackground({
+    Key? key,
+  }) : super(key: key);
 
-//   @override
-//   Widget build(BuildContext context) => Column(
-//         mainAxisAlignment: MainAxisAlignment.center,
-//         mainAxisSize: MainAxisSize.max,
-//         children: [
-//           Container(
-//             margin: EdgeInsets.only(bottom: MoonSpacerSize.xxxs.kSize),
-//             decoration: const BoxDecoration(
-//               color: Colors.white,
-//               borderRadius: BorderRadius.all(
-//                 Radius.circular(5),
-//               ),
-//             ),
-//             height: 4,
-//             width: 64,
-//           ),
-//           Expanded(
-//             child: Container(
-//               decoration: BoxDecoration(
-//                 color: MoonContantsColors.secondaryDark,
-//                 borderRadius: BorderRadius.only(
-//                   topLeft: Radius.circular(MoonSpacerSize.xxs.kSize),
-//                   topRight: Radius.circular(MoonSpacerSize.xxs.kSize),
-//                 ),
-//               ),
-//             ),
-//           ),
-//           Expanded(
-//             child: Container(
-//               decoration: const BoxDecoration(
-//                 color: MoonContantsColors.secondaryDarker,
-//               ),
-//             ),
-//           ),
-//         ],
-//       );
-// }}
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Container(
+            margin: const EdgeInsets.only(bottom: 9),
+            decoration: const BoxDecoration(
+              color: UColors.textDark,
+              borderRadius: BorderRadius.all(
+                Radius.circular(5),
+              ),
+            ),
+            height: 2,
+            width: 72,
+          ),
+          Expanded(
+            child: Container(
+              decoration: const BoxDecoration(
+                color: UColors.modalDark,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(20),
+                  topRight: Radius.circular(20),
+                ),
+              ),
+            ),
+          ),
+          // Expanded(
+          //   child: Container(
+          //     decoration: const BoxDecoration(
+          //       color: MoonContantsColors.secondaryDarker,
+          //     ),
+          //   ),
+          // ),
+        ],
+      );
+}

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_template.dart
@@ -18,8 +18,8 @@ class UBottomSheet {
         isDismissible: true,
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(20),
-            topRight: Radius.circular(20),
+            topLeft: Radius.circular(USizes.barAboveBottomSheetBorderRadius),
+            topRight: Radius.circular(USizes.barAboveBottomSheetBorderRadius),
           ),
         ),
         builder: (context) {
@@ -27,23 +27,25 @@ class UBottomSheet {
             children: [
               Center(
                 child: Container(
-                  margin: const EdgeInsets.only(bottom: 9),
+                  margin: const EdgeInsets.only(bottom: 8),
                   decoration: const BoxDecoration(
                     color: UColors.textDark,
                     borderRadius: BorderRadius.all(
-                      Radius.circular(5),
+                      Radius.circular(USizes.barAboveBottomSheetBorderRadius),
                     ),
                   ),
-                  height: 2,
-                  width: 72,
+                  height: USizes.barAboveBottomSheetHeightSize,
+                  width: USizes.barAboveBottomSheetWidthSize,
                 ),
               ),
               Container(
                 decoration: const BoxDecoration(
                   color: UColors.modalDark,
                   borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(20),
-                    topRight: Radius.circular(20),
+                    topLeft:
+                        Radius.circular(USizes.bottomSheetTemplateBorderRadius),
+                    topRight:
+                        Radius.circular(USizes.bottomSheetTemplateBorderRadius),
                   ),
                 ),
                 child: child,
@@ -52,47 +54,4 @@ class UBottomSheet {
           );
         });
   }
-}
-
-class _BottomSheetBackground extends StatelessWidget {
-  const _BottomSheetBackground({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) => Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.max,
-        children: [
-          Container(
-            margin: const EdgeInsets.only(bottom: 9),
-            decoration: const BoxDecoration(
-              color: UColors.textDark,
-              borderRadius: BorderRadius.all(
-                Radius.circular(5),
-              ),
-            ),
-            height: 2,
-            width: 72,
-          ),
-          Expanded(
-            child: Container(
-              decoration: const BoxDecoration(
-                color: UColors.modalDark,
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(20),
-                  topRight: Radius.circular(20),
-                ),
-              ),
-            ),
-          ),
-          // Expanded(
-          //   child: Container(
-          //     decoration: const BoxDecoration(
-          //       color: MoonContantsColors.secondaryDarker,
-          //     ),
-          //   ),
-          // ),
-        ],
-      );
 }

--- a/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_two_buttons.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/bottom_sheet_two_buttons.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+import 'package:ui_library/widgets/bottom_sheet/bottom_sheet_template.dart';
+
+class UBottomSheetTwoButtons {
+  final BuildContext context;
+
+  final String header;
+
+  final String firstButtonText;
+  final VoidCallback firstButtonOnPressed;
+  final UIconData? firstButtonIcon;
+
+  final String secondButtonText;
+  final VoidCallback secondButtonOnPressed;
+  final UIconData? secondButtonIcon;
+
+  UBottomSheetTwoButtons(
+    this.context, {
+    required this.firstButtonOnPressed,
+    required this.secondButtonOnPressed,
+    required this.header,
+    required this.firstButtonText,
+    this.firstButtonIcon,
+    required this.secondButtonText,
+    this.secondButtonIcon,
+  });
+
+  Future show() {
+    return UBottomSheet(
+      context,
+      _UBottomSheetTwoButtonsBody(
+        header: header,
+        firstButtonOnPressed: firstButtonOnPressed,
+        firstButtonText: firstButtonText,
+        firstButtonIcon: firstButtonIcon,
+        secondButtonOnPressed: secondButtonOnPressed,
+        secondButtonText: secondButtonText,
+        secondButtonIcon: secondButtonIcon,
+      ),
+    ).show();
+  }
+}
+
+class _UBottomSheetTwoButtonsBody extends StatelessWidget {
+  const _UBottomSheetTwoButtonsBody(
+      {Key? key,
+      required this.header,
+      required this.firstButtonText,
+      this.firstButtonIcon,
+      required this.secondButtonText,
+      this.secondButtonIcon,
+      required this.firstButtonOnPressed,
+      required this.secondButtonOnPressed})
+      : super(key: key);
+
+  final String header;
+
+  final String firstButtonText;
+  final VoidCallback firstButtonOnPressed;
+  final UIconData? firstButtonIcon;
+
+  final String secondButtonText;
+  final VoidCallback secondButtonOnPressed;
+  final UIconData? secondButtonIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
+      child: Column(
+        children: [
+          UText(
+            header,
+            textStyle: UTextStyle.H5_fifthHeader,
+          ),
+          const SizedBox.square(
+            dimension: 16,
+          ),
+          Row(
+            children: [
+              if (firstButtonIcon == null) ...[
+                UButton.filled2(
+                  label: firstButtonText,
+                  onPressed: firstButtonOnPressed,
+                )
+              ] else ...[
+                UButton.secondary(
+                    label: firstButtonText,
+                    uIconData: firstButtonIcon!,
+                    onPressed: firstButtonOnPressed),
+              ],
+              const SizedBox.square(
+                dimension: 8,
+              ),
+              if (secondButtonIcon == null) ...[
+                UButton.filled1(
+                  label: secondButtonText,
+                  onPressed: secondButtonOnPressed,
+                )
+              ] else ...[
+                UButton.primary(
+                    label: secondButtonText,
+                    uIconData: secondButtonIcon!,
+                    onPressed: secondButtonOnPressed),
+              ]
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_pin.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_pin.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+import 'package:ui_library/widgets/bottom_sheet/bottom_sheet_template.dart';
+
+class UBottomSheetPin {
+  final BuildContext context;
+
+  final Function(int) onSelect;
+
+  /// Creates a bottom sheet to use in Pin Pages
+  ///
+  /// It allows to select between 4, 6 or 8 digits as pin length
+  ///
+  /// To use, is necessary to call the class and the method [show]
+  ///
+  /// You need to call an action to show the [UBottomSheetPin],
+  /// example:
+  /// ```dart
+  /// UButton.filled1(
+  ///     label: 'Click here to see the bottom sheet',
+  ///       onPressed: () {
+  ///         UBottomSheetPin(
+  ///             context,
+  ///             onSelect: (p0) {},
+  ///         ).show();
+  /// }),
+  /// ```
+  UBottomSheetPin(
+    this.context, {
+    required this.onSelect,
+  });
+
+  Future show() {
+    return UBottomSheet(
+      context,
+      child: _UBottomSheetPinBody(
+        onSelect: onSelect,
+      ),
+    ).show();
+  }
+}
+
+class _UBottomSheetPinBody extends StatefulWidget {
+  const _UBottomSheetPinBody({
+    Key? key,
+    required this.onSelect,
+  }) : super(key: key);
+
+  final Function(int) onSelect;
+
+  @override
+  State<_UBottomSheetPinBody> createState() => _UBottomSheetPinBodyState();
+}
+
+class _UBottomSheetPinBodyState extends State<_UBottomSheetPinBody> {
+  bool _isFourDigitsSelected = false;
+  bool _isSixDigitsSelected = false;
+  bool _isEightDigitsSelected = false;
+
+  void _selectTheNumberOfDigits(int value) {
+    setState(() {
+      _isFourDigitsSelected = value == 4 ? true : false;
+      _isSixDigitsSelected = value == 6 ? true : false;
+      _isEightDigitsSelected = value == 8 ? true : false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 36, 19, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const UText(
+            'Pin Options',
+            textStyle: UTextStyle.H3_tertiaryHeader,
+          ),
+          const SizedBox.square(
+            dimension: 26,
+          ),
+          _PinOption(
+            onSelect: (p0) {
+              _selectTheNumberOfDigits(p0);
+              widget.onSelect(p0);
+            },
+            numberOfDigits: 4,
+            digitSelected: _isFourDigitsSelected,
+          ),
+          const SizedBox.square(
+            dimension: 33,
+          ),
+          _PinOption(
+            onSelect: (p0) {
+              _selectTheNumberOfDigits(p0);
+              widget.onSelect(p0);
+            },
+            numberOfDigits: 6,
+            digitSelected: _isSixDigitsSelected,
+          ),
+          const SizedBox.square(
+            dimension: 33,
+          ),
+          _PinOption(
+            onSelect: (p0) {
+              _selectTheNumberOfDigits(p0);
+              widget.onSelect(p0);
+            },
+            numberOfDigits: 8,
+            digitSelected: _isEightDigitsSelected,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PinOption extends StatelessWidget {
+  const _PinOption({
+    Key? key,
+    required this.onSelect,
+    required this.numberOfDigits,
+    required this.digitSelected,
+  }) : super(key: key);
+
+  final Function(int) onSelect;
+  final int numberOfDigits;
+  final bool digitSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final _valueToAnimate = digitSelected ? 1.0 : 0.0;
+    const _animationDuration = Duration(milliseconds: 150);
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        onSelect(numberOfDigits);
+      },
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          UText('$numberOfDigits Digits',
+              textStyle: UTextStyle.BUT1_primaryButton),
+          AnimatedScale(
+            scale: _valueToAnimate,
+            duration: _animationDuration,
+            child: AnimatedOpacity(
+              opacity: _valueToAnimate,
+              duration: _animationDuration,
+              child: const UIcon(
+                UIcons.checkmark,
+                color: UColors.ctaBlue,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_pin.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_pin.dart
@@ -9,7 +9,9 @@ class UBottomSheetPin {
 
   /// Creates a bottom sheet to use in Pin Pages
   ///
-  /// It allows to select between 4, 6 or 8 digits as pin length
+  /// It allows to select between 4, 6 or 8 digits as pin length.
+  ///
+  /// [onSelect] method will return the number of selected integer type digits
   ///
   /// To use, is necessary to call the class and the method [show]
   ///

--- a/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_two_buttons.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_two_buttons.dart
@@ -29,7 +29,7 @@ class UBottomSheetTwoButtons {
   Future show() {
     return UBottomSheet(
       context,
-      _UBottomSheetTwoButtonsBody(
+      child: _UBottomSheetTwoButtonsBody(
         header: header,
         firstButtonOnPressed: firstButtonOnPressed,
         firstButtonText: firstButtonText,
@@ -67,8 +67,9 @@ class _UBottomSheetTwoButtonsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
+      padding: const EdgeInsets.fromLTRB(16, 30, 16, 20),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           UText(
             header,
@@ -80,32 +81,40 @@ class _UBottomSheetTwoButtonsBody extends StatelessWidget {
           Row(
             children: [
               if (firstButtonIcon == null) ...[
-                UButton.filled2(
-                  label: firstButtonText,
-                  onPressed: firstButtonOnPressed,
+                Expanded(
+                  child: UButton.filled2(
+                    label: firstButtonText,
+                    onPressed: firstButtonOnPressed,
+                  ),
                 )
               ] else ...[
-                UButton.secondary(
-                    label: firstButtonText,
-                    uIconData: firstButtonIcon!,
-                    onPressed: firstButtonOnPressed),
+                Expanded(
+                  child: UButton.secondary(
+                      label: firstButtonText,
+                      uIconData: firstButtonIcon!,
+                      onPressed: firstButtonOnPressed),
+                ),
               ],
               const SizedBox.square(
                 dimension: 8,
               ),
               if (secondButtonIcon == null) ...[
-                UButton.filled1(
-                  label: secondButtonText,
-                  onPressed: secondButtonOnPressed,
+                Expanded(
+                  child: UButton.filled1(
+                    label: secondButtonText,
+                    onPressed: secondButtonOnPressed,
+                  ),
                 )
               ] else ...[
-                UButton.primary(
-                    label: secondButtonText,
-                    uIconData: secondButtonIcon!,
-                    onPressed: secondButtonOnPressed),
-              ]
+                Expanded(
+                  child: UButton.primary(
+                      label: secondButtonText,
+                      uIconData: secondButtonIcon!,
+                      onPressed: secondButtonOnPressed),
+                ),
+              ],
             ],
-          )
+          ),
         ],
       ),
     );

--- a/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_two_buttons.dart
+++ b/packages/ui_library/lib/widgets/bottom_sheet/u_bottom_sheet_two_buttons.dart
@@ -5,16 +5,44 @@ import 'package:ui_library/widgets/bottom_sheet/bottom_sheet_template.dart';
 class UBottomSheetTwoButtons {
   final BuildContext context;
 
+  /// The text on the top of the bottom sheet
   final String header;
 
   final String firstButtonText;
   final VoidCallback firstButtonOnPressed;
+
+  /// If is null, the button will not have an icon
   final UIconData? firstButtonIcon;
 
   final String secondButtonText;
   final VoidCallback secondButtonOnPressed;
+
+  /// If is null, the button will not have an icon
   final UIconData? secondButtonIcon;
 
+  /// Creates a bottom sheet to use with two button options
+  ///
+  /// It is possible to use buttons with or without icons
+  ///
+  /// To use, is necessary to call the class and the method [show]
+  ///
+  /// You need to call an action to show the [UBottomSheetTwoButtons],
+  /// example:
+  /// ```dart
+  /// UButton.filled1(
+  ///   label: 'Click here to see the bottom sheet',
+  ///    onPressed: () {
+  ///      UBottomSheetTwoButtons(context,
+  ///         firstButtonIcon: UIcons.add_button,
+  ///         secondButtonIcon: UIcons.add_contact_member,
+  ///         firstButtonOnPressed: () {},
+  ///         secondButtonOnPressed: () {},
+  ///         header: 'Bottom Sheet with two UButtons with icons',
+  ///         firstButtonText: 'First Button',
+  ///         secondButtonText: 'Second Button')
+  ///            .show();
+  ///   }),
+  /// ```
   UBottomSheetTwoButtons(
     this.context, {
     required this.firstButtonOnPressed,

--- a/packages/ui_library/lib/widgets/buttons/u_button/u_button.dart
+++ b/packages/ui_library/lib/widgets/buttons/u_button/u_button.dart
@@ -5,11 +5,14 @@ enum _ButtonType { primary, secondary, filled1, filled2 }
 
 class UButton extends StatelessWidget {
   final _ButtonType _buttonType;
-  final String? _label;
+  final String _label;
   final UIconData? _uIconData;
   final VoidCallback _onPressed;
 
   ///[ElevatedButton] with Text and Icon:
+  ///
+  /// backgrounColor is [UColors.ctaBlue]
+  ///
   ///```dart
   /// UButton.primary(
   ///    label: 'ButtonText',
@@ -29,6 +32,9 @@ class UButton extends StatelessWidget {
         super(key: key);
 
   ///[ElevatedButton] with Text and Icon:
+  ///
+  /// backgrounColor is [UColors.ctaDark]
+  ///
   ///```dart
   /// UButton.secondary(
   ///    label: 'ButtonText',
@@ -48,6 +54,9 @@ class UButton extends StatelessWidget {
         super(key: key);
 
   ///[ElevatedButton] with Text only:
+  ///
+  /// backgrounColor is [UColors.ctaBlue]
+  ///
   ///```dart
   /// UButton.filled1(
   ///    label: 'ButtonText',
@@ -63,6 +72,9 @@ class UButton extends StatelessWidget {
         super(key: key);
 
   ///[ElevatedButton] with Text only:
+  ///
+  /// backgrounColor is [UColors.ctaDark]
+  ///
   ///```dart
   /// UButton.filled2(
   ///    label: 'ButtonText',
@@ -96,13 +108,14 @@ class UButton extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (_uIconData != null) UIcon(_uIconData!),
-            if (_uIconData != null && _label != null) const SizedBox(width: 8),
-            if (_label != null)
-              UText(
-                _label!,
-                textStyle: UTextStyle.BUT1_primaryButton,
-              ),
+            if (_uIconData != null) ...[
+              UIcon(_uIconData!),
+              const SizedBox(width: 8),
+            ],
+            UText(
+              _label,
+              textStyle: UTextStyle.BUT1_primaryButton,
+            ),
           ],
         ));
   }

--- a/packages/ui_library/lib/widgets/widgets_export.dart
+++ b/packages/ui_library/lib/widgets/widgets_export.dart
@@ -4,3 +4,4 @@ export 'u_user_profile/user_profile_export.dart';
 export 'u_avatars_profile/avatar_profile_export.dart';
 export 'buttons/buttons_export.dart';
 export 'u_recovery_seed_box/u_recovery_seed_box_export.dart';
+export 'bottom_sheet/bottom_sheet_export.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/bottom_sheet_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/bottom_sheet_export.dart
@@ -1,0 +1,1 @@
+export 'u_bottom_sheet_two_buttons.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/bottom_sheet_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/bottom_sheet_export.dart
@@ -1,1 +1,2 @@
 export 'u_bottom_sheet_two_buttons.dart';
+export 'u_bottom_sheet_pin.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_pin.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_pin.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+
+class UBottomSheetPinPage extends StatelessWidget {
+  const UBottomSheetPinPage({Key? key}) : super(key: key);
+
+  static const routeName = '/UBottomSheetPin';
+
+  @override
+  Widget build(BuildContext context) {
+    final ValueNotifier<int> digitSelected = ValueNotifier(4);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(routeName.substring(1)),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Center(
+          child: ListView(
+            children: [
+              const UText(
+                'Bottom Sheet to select the number of digits on Pin Page',
+                textStyle: UTextStyle.H1_primaryHeader,
+              ),
+              const SizedBox.square(
+                dimension: 8,
+              ),
+              UButton.filled1(
+                  label: 'Click here to see the bottom sheet',
+                  onPressed: () {
+                    UBottomSheetPin(
+                      context,
+                      onSelect: (p0) {
+                        digitSelected.value = p0;
+                      },
+                    ).show();
+                  }),
+              const SizedBox.square(
+                dimension: 32,
+              ),
+              ValueListenableBuilder(
+                  valueListenable: digitSelected,
+                  builder: (BuildContext context, int int, Widget? widget) {
+                    return Center(
+                      child: UText(
+                        '${digitSelected.value} Digits was selected!',
+                        textStyle: UTextStyle.H2_secondaryHeader,
+                      ),
+                    );
+                  }),
+              const SizedBox.square(
+                dimension: 16,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_two_buttons.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_two_buttons.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+
+class UBottomSheetTwoButtonsPage extends StatelessWidget {
+  const UBottomSheetTwoButtonsPage({Key? key}) : super(key: key);
+
+  static const routeName = '/UBottomSheetTwoButtons';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(routeName.substring(1)),
+      ),
+      body: Center(
+        child: ListView(
+          children: [
+            const UText(
+              'Bottom Sheet Two Buttons without icons',
+              textStyle: UTextStyle.H1_primaryHeader,
+            ),
+            const SizedBox.square(
+              dimension: 8,
+            ),
+            UButton.filled1(
+                label: 'Click here to see the bottom sheet',
+                onPressed: () {
+                  UBottomSheetTwoButtons(context,
+                          firstButtonOnPressed: () {},
+                          secondButtonOnPressed: () {},
+                          header:
+                              'Bottom Sheet with two UButtons without icons',
+                          firstButtonText: 'First Button',
+                          secondButtonText: 'Second Button')
+                      .show();
+                }),
+            const SizedBox.square(
+              dimension: 16,
+            ),
+            const UText(
+              'Bottom Sheet Two Buttons with icons',
+              textStyle: UTextStyle.H1_primaryHeader,
+            ),
+            const SizedBox.square(
+              dimension: 8,
+            ),
+            UButton.filled1(
+                label: 'Click here to see the bottom sheet',
+                onPressed: () {
+                  UBottomSheetTwoButtons(context,
+                          firstButtonIcon: UIcons.add_button,
+                          secondButtonIcon: UIcons.add_contact_member,
+                          firstButtonOnPressed: () {},
+                          secondButtonOnPressed: () {},
+                          header: 'Bottom Sheet with two UButtons with icons',
+                          firstButtonText: 'First Button',
+                          secondButtonText: 'Second Button')
+                      .show();
+                }),
+            const SizedBox.square(
+              dimension: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_two_buttons.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/bottom_sheet/u_bottom_sheet_two_buttons.dart
@@ -12,55 +12,58 @@ class UBottomSheetTwoButtonsPage extends StatelessWidget {
       appBar: AppBar(
         title: Text(routeName.substring(1)),
       ),
-      body: Center(
-        child: ListView(
-          children: [
-            const UText(
-              'Bottom Sheet Two Buttons without icons',
-              textStyle: UTextStyle.H1_primaryHeader,
-            ),
-            const SizedBox.square(
-              dimension: 8,
-            ),
-            UButton.filled1(
-                label: 'Click here to see the bottom sheet',
-                onPressed: () {
-                  UBottomSheetTwoButtons(context,
-                          firstButtonOnPressed: () {},
-                          secondButtonOnPressed: () {},
-                          header:
-                              'Bottom Sheet with two UButtons without icons',
-                          firstButtonText: 'First Button',
-                          secondButtonText: 'Second Button')
-                      .show();
-                }),
-            const SizedBox.square(
-              dimension: 16,
-            ),
-            const UText(
-              'Bottom Sheet Two Buttons with icons',
-              textStyle: UTextStyle.H1_primaryHeader,
-            ),
-            const SizedBox.square(
-              dimension: 8,
-            ),
-            UButton.filled1(
-                label: 'Click here to see the bottom sheet',
-                onPressed: () {
-                  UBottomSheetTwoButtons(context,
-                          firstButtonIcon: UIcons.add_button,
-                          secondButtonIcon: UIcons.add_contact_member,
-                          firstButtonOnPressed: () {},
-                          secondButtonOnPressed: () {},
-                          header: 'Bottom Sheet with two UButtons with icons',
-                          firstButtonText: 'First Button',
-                          secondButtonText: 'Second Button')
-                      .show();
-                }),
-            const SizedBox.square(
-              dimension: 16,
-            ),
-          ],
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Center(
+          child: ListView(
+            children: [
+              const UText(
+                'Bottom Sheet Two Buttons without icons',
+                textStyle: UTextStyle.H1_primaryHeader,
+              ),
+              const SizedBox.square(
+                dimension: 8,
+              ),
+              UButton.filled1(
+                  label: 'Click here to see the bottom sheet',
+                  onPressed: () {
+                    UBottomSheetTwoButtons(context,
+                            firstButtonOnPressed: () {},
+                            secondButtonOnPressed: () {},
+                            header:
+                                'Bottom Sheet with two UButtons without icons',
+                            firstButtonText: 'First Button',
+                            secondButtonText: 'Second Button')
+                        .show();
+                  }),
+              const SizedBox.square(
+                dimension: 16,
+              ),
+              const UText(
+                'Bottom Sheet Two Buttons with icons',
+                textStyle: UTextStyle.H1_primaryHeader,
+              ),
+              const SizedBox.square(
+                dimension: 8,
+              ),
+              UButton.filled1(
+                  label: 'Click here to see the bottom sheet',
+                  onPressed: () {
+                    UBottomSheetTwoButtons(context,
+                            firstButtonIcon: UIcons.add_button,
+                            secondButtonIcon: UIcons.add_contact_member,
+                            firstButtonOnPressed: () {},
+                            secondButtonOnPressed: () {},
+                            header: 'Bottom Sheet with two UButtons with icons',
+                            firstButtonText: 'First Button',
+                            secondButtonText: 'Second Button')
+                        .show();
+                  }),
+              const SizedBox.square(
+                dimension: 16,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/ui_showroom/lib/ui_showroom_page.dart
+++ b/packages/ui_showroom/lib/ui_showroom_page.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:ui_library/ui_library_export.dart';
+import 'package:ui_showroom/ui_pages/src/bottom_sheet/bottom_sheet_export.dart';
 import 'package:ui_showroom/ui_pages/ui_pages_export.dart';
 
 class UIShowRoomApp extends StatelessWidget {
@@ -27,6 +28,8 @@ class UIShowRoomApp extends StatelessWidget {
         UIconButtonPage.routeName: (context) => const UIconButtonPage(),
         UFABPage.routeName: (context) => const UFABPage(),
         ULogoutButtonPage.routeName: (context) => const ULogoutButtonPage(),
+        UBottomSheetTwoButtonsPage.routeName: (context) =>
+            const UBottomSheetTwoButtonsPage(),
       },
       home: Scaffold(
         appBar: AppBar(
@@ -96,6 +99,14 @@ class UIShowRoomApp extends StatelessWidget {
                   ),
                   WidgetPageButton(
                     widgetName: ULogoutButtonPage.routeName,
+                  ),
+                ],
+              ),
+              const _WidgetsShowSession(
+                sessionTitle: 'Bottom sheets',
+                sessionWidgets: [
+                  WidgetPageButton(
+                    widgetName: UBottomSheetTwoButtonsPage.routeName,
                   ),
                 ],
               ),

--- a/packages/ui_showroom/lib/ui_showroom_page.dart
+++ b/packages/ui_showroom/lib/ui_showroom_page.dart
@@ -30,6 +30,7 @@ class UIShowRoomApp extends StatelessWidget {
         ULogoutButtonPage.routeName: (context) => const ULogoutButtonPage(),
         UBottomSheetTwoButtonsPage.routeName: (context) =>
             const UBottomSheetTwoButtonsPage(),
+        UBottomSheetPinPage.routeName: (context) => const UBottomSheetPinPage(),
       },
       home: Scaffold(
         appBar: AppBar(
@@ -107,6 +108,9 @@ class UIShowRoomApp extends StatelessWidget {
                 sessionWidgets: [
                   WidgetPageButton(
                     widgetName: UBottomSheetTwoButtonsPage.routeName,
+                  ),
+                  WidgetPageButton(
+                    widgetName: UBottomSheetPinPage.routeName,
                   ),
                 ],
               ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

1. Created a bottomSheet template to be used to create other bottomSheets. It contains the backgroundColor, the navBar, the rounded borders. To use a bottom is necessary to call the widget and call a method show().

2. Created a bottomSheet to use with text and two buttons. 

https://user-images.githubusercontent.com/63157656/168352384-1325e4c2-13a9-4adf-955b-b5a382512b3a.mov

3. Created a bottomSheet to select the number of the digits on Pin Page.

https://user-images.githubusercontent.com/63157656/168354063-bb8bb6b6-b3ba-4441-8e2d-51b90b79d8e4.mov



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ x ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
