### PR TITLE
feat(LoadingContactsIndexPage): Add loading page for ContactsIndexPage and add UShimmer Widgets in the showroom -UL-157

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -14,7 +14,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const _appToBuild = Apps.mainApp;
+    const _appToBuild = Apps.uiShowroom;
 
     return ChangeNotifierProvider(
       create: (context) => ThemeModel(),

--- a/packages/ui_library/lib/core/const/u_colors.dart
+++ b/packages/ui_library/lib/core/const/u_colors.dart
@@ -49,4 +49,13 @@ class UColors {
 
   /// FF6F748A
   static const textDark = Color(0xFF6F748A);
+
+  /// FF1C1C29
+  static const loadDark = Color(0xFF1C1C29);
+
+  /// FF2B2B3B
+  static const loadMed = Color(0xFF2B2B3B);
+
+  /// FF38384C
+  static const loadLight = Color(0xFF38384C);
 }

--- a/packages/ui_library/lib/widgets/shimmers/shimmers_export.dart
+++ b/packages/ui_library/lib/widgets/shimmers/shimmers_export.dart
@@ -1,0 +1,2 @@
+export 'u_shimmer/u_shimmer.dart';
+export 'u_rect_container/u_rect_container.dart';

--- a/packages/ui_library/lib/widgets/shimmers/u_rect_container/u_rect_container.dart
+++ b/packages/ui_library/lib/widgets/shimmers/u_rect_container/u_rect_container.dart
@@ -7,15 +7,18 @@ class URectContainer extends StatelessWidget {
     this.height,
     this.width,
     this.bordRadius,
+    this.margin,
   }) : super(key: key);
 
   final double? height;
   final double? width;
   final BorderRadiusGeometry? bordRadius;
+  final EdgeInsetsGeometry? margin;
 
   @override
   Widget build(BuildContext context) {
     return Container(
+      margin: margin,
       height: height,
       width: width,
       decoration: BoxDecoration(

--- a/packages/ui_library/lib/widgets/shimmers/u_rect_container/u_rect_container.dart
+++ b/packages/ui_library/lib/widgets/shimmers/u_rect_container/u_rect_container.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// Container with a default border redius 4
+class URectContainer extends StatelessWidget {
+  const URectContainer({
+    Key? key,
+    this.height,
+    this.width,
+    this.bordRadius,
+  }) : super(key: key);
+
+  final double? height;
+  final double? width;
+  final BorderRadiusGeometry? bordRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: width,
+      decoration: BoxDecoration(
+        borderRadius: bordRadius ?? BorderRadius.circular(4),
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
+++ b/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+import 'package:ui_library/core/const/u_colors.dart';
+
+enum ShimmerColor { dark, med, light, white }
+
+class UShimmer extends StatelessWidget {
+  final ShimmerColor shimmerColor;
+  final Widget child;
+
+  const UShimmer.dark({
+    Key? key,
+    required this.child,
+  })  : shimmerColor = ShimmerColor.dark,
+        super(key: key);
+  const UShimmer.med({
+    Key? key,
+    required this.child,
+  })  : shimmerColor = ShimmerColor.med,
+        super(key: key);
+  const UShimmer.light({
+    Key? key,
+    required this.child,
+  })  : shimmerColor = ShimmerColor.light,
+        super(key: key);
+  const UShimmer.white({
+    Key? key,
+    required this.child,
+  })  : shimmerColor = ShimmerColor.white,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Color _baseColor = UColors.white;
+    Color _highlightColor = Colors.white;
+
+    switch (shimmerColor) {
+      case ShimmerColor.dark:
+        _baseColor = UColors.loadDark;
+        _highlightColor = UColors.loadMed;
+        break;
+      case ShimmerColor.med:
+        _baseColor = UColors.loadMed;
+        _highlightColor = UColors.loadLight;
+        break;
+      case ShimmerColor.light:
+        _baseColor = UColors.loadLight;
+        _highlightColor = UColors.white;
+        break;
+      default:
+    }
+
+    return Shimmer.fromColors(
+      baseColor: _baseColor,
+      highlightColor: _highlightColor,
+      child: child,
+    );
+  }
+}

--- a/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
+++ b/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
@@ -9,24 +9,59 @@ class UShimmer extends StatelessWidget {
   final Widget child;
   final bool? enabled;
 
+  /// Create a widget with a [UColors.loadDark] shimmer effect
+  ///```dart
+  /// UShimmer.dark(
+  ///    child: URectContainer(
+  ///           height: 20,
+  ///           ),
+  /// ),
+  ///```
   const UShimmer.dark({
     Key? key,
     required this.child,
     this.enabled,
   })  : shimmerColor = ShimmerColor.dark,
         super(key: key);
+
+  /// Create a widget with a [UColors.loadMed] shimmer effect
+  /// ```dart
+  /// UShimmer.med(
+  ///    child: URectContainer(
+  ///           height: 20,
+  ///           ),
+  /// ),
+  ///```
   const UShimmer.med({
     Key? key,
     required this.child,
     this.enabled,
   })  : shimmerColor = ShimmerColor.med,
         super(key: key);
+
+  /// Create a widget with a [UColors.loadLight] shimmer effect
+  /// ```dart
+  /// UShimmer.light(
+  ///    child: URectContainer(
+  ///           height: 20,
+  ///           ),
+  /// ),
+  ///```
   const UShimmer.light({
     Key? key,
     required this.child,
     this.enabled,
   })  : shimmerColor = ShimmerColor.light,
         super(key: key);
+
+  /// Create a widget with a [UColors.white] shimmer effect
+  /// ```dart
+  /// UShimmer.white(
+  ///    child: URectContainer(
+  ///           height: 20,
+  ///           ),
+  /// ),
+  ///```
   const UShimmer.white({
     Key? key,
     required this.child,

--- a/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
+++ b/packages/ui_library/lib/widgets/shimmers/u_shimmer/u_shimmer.dart
@@ -7,25 +7,30 @@ enum ShimmerColor { dark, med, light, white }
 class UShimmer extends StatelessWidget {
   final ShimmerColor shimmerColor;
   final Widget child;
+  final bool? enabled;
 
   const UShimmer.dark({
     Key? key,
     required this.child,
+    this.enabled,
   })  : shimmerColor = ShimmerColor.dark,
         super(key: key);
   const UShimmer.med({
     Key? key,
     required this.child,
+    this.enabled,
   })  : shimmerColor = ShimmerColor.med,
         super(key: key);
   const UShimmer.light({
     Key? key,
     required this.child,
+    this.enabled,
   })  : shimmerColor = ShimmerColor.light,
         super(key: key);
   const UShimmer.white({
     Key? key,
     required this.child,
+    this.enabled,
   })  : shimmerColor = ShimmerColor.white,
         super(key: key);
 
@@ -54,6 +59,7 @@ class UShimmer extends StatelessWidget {
       baseColor: _baseColor,
       highlightColor: _highlightColor,
       child: child,
+      enabled: enabled ?? true,
     );
   }
 }

--- a/packages/ui_library/lib/widgets/widgets_export.dart
+++ b/packages/ui_library/lib/widgets/widgets_export.dart
@@ -23,3 +23,4 @@ export 'u_popup_menu_item/u_popup_menu_item_export.dart';
 export 'notifications/notifications_export.dart';
 export 'contacts/u_account_id_box.dart';
 export 'text_input/u_text_input.dart';
+export 'shimmers/shimmers_export.dart';

--- a/packages/ui_library/pubspec.yaml
+++ b/packages/ui_library/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   html: ^0.15.0
   given_when_then_unit_test: ^0.1.0
   shouldly: ^0.5.0+1
+  shimmer: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/ui_showroom/lib/ui_pages/src/core_widgets/u_colors_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/core_widgets/u_colors_page.dart
@@ -14,6 +14,9 @@ Map<String, Color> colorsMap = {
   'defGrey': UColors.defGrey,
   'textMed': UColors.textMed,
   'textDark': UColors.textDark,
+  'loadDark': UColors.loadDark,
+  'loadMed': UColors.loadMed,
+  'loadLight': UColors.loadLight,
 };
 
 class UColorsPage extends StatelessWidget {

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_contacts_index_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_contacts_index_page.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+
+class LoadingContactsIndexPage extends StatelessWidget {
+  const LoadingContactsIndexPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final topSpacing = MediaQuery.of(context).padding.top;
+    return Column(
+      children: [
+        SizedBox(
+          height: topSpacing,
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        UShimmer.dark(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: const [
+                    URectContainer(
+                      height: 24,
+                      width: 24,
+                    ),
+                    SizedBox(width: 16),
+                    URectContainer(
+                      height: 27,
+                      width: 152,
+                    ),
+                  ],
+                ),
+                Row(
+                  children: const [
+                    URectContainer(
+                      height: 24,
+                      width: 24,
+                    ),
+                    SizedBox(width: 24),
+                    URectContainer(
+                      height: 24,
+                      width: 24,
+                    ),
+                    SizedBox(width: 24),
+                    URectContainer(
+                      height: 24,
+                      width: 24,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 17),
+        UShimmer.dark(
+          child: Row(
+            children: const [
+              SizedBox(
+                width: 16,
+              ),
+              Expanded(
+                child: URectContainer(
+                  height: 21,
+                  bordRadius: BorderRadius.horizontal(
+                    left: Radius.circular(4),
+                  ),
+                ),
+              )
+            ],
+          ),
+        ),
+        const SizedBox(
+          height: 15,
+        ),
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            physics: const NeverScrollableScrollPhysics(),
+            separatorBuilder: (context, index) => const SizedBox(height: 20),
+            itemBuilder: (context, index) => Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const UShimmer.med(child: CircleAvatar()),
+                const SizedBox(
+                  width: 12,
+                ),
+                Expanded(
+                  child: Column(
+                    children: const [
+                      UShimmer.med(child: URectContainer(height: 19)),
+                      SizedBox(height: 2),
+                      UShimmer.dark(
+                        child: URectContainer(
+                          height: 18,
+                        ),
+                      )
+                    ],
+                  ),
+                )
+              ],
+            ),
+            itemCount: 15,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_contacts_index_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_contacts_index_page.dart
@@ -20,37 +20,31 @@ class LoadingContactsIndexPage extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  children: const [
-                    URectContainer(
-                      height: 24,
-                      width: 24,
-                    ),
-                    SizedBox(width: 16),
-                    URectContainer(
-                      height: 27,
-                      width: 152,
-                    ),
-                  ],
+              children: const [
+                URectContainer(
+                  height: 24,
+                  width: 24,
                 ),
-                Row(
-                  children: const [
-                    URectContainer(
-                      height: 24,
-                      width: 24,
-                    ),
-                    SizedBox(width: 24),
-                    URectContainer(
-                      height: 24,
-                      width: 24,
-                    ),
-                    SizedBox(width: 24),
-                    URectContainer(
-                      height: 24,
-                      width: 24,
-                    ),
-                  ],
+                SizedBox(width: 16),
+                Expanded(
+                  child: URectContainer(
+                    height: 27,
+                  ),
+                ),
+                SizedBox(width: 16),
+                URectContainer(
+                  height: 24,
+                  width: 24,
+                ),
+                SizedBox(width: 24),
+                URectContainer(
+                  height: 24,
+                  width: 24,
+                ),
+                SizedBox(width: 24),
+                URectContainer(
+                  height: 24,
+                  width: 24,
                 ),
               ],
             ),

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_pages_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_pages_export.dart
@@ -1,0 +1,1 @@
+export 'loading_contacts_index_page.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_export.dart
@@ -1,1 +1,2 @@
 export 'u_shimmer_page.dart';
+export 'shimmer_loading_page.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_export.dart
@@ -1,0 +1,1 @@
+export 'u_shimmer_page.dart';

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_loading_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/shimmer_loading_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+import 'package:ui_showroom/ui_pages/src/shimmer/loading_pages/loading_pages_export.dart';
+
+class ShimmerLoadingPage extends StatefulWidget {
+  const ShimmerLoadingPage({Key? key}) : super(key: key);
+  static const routeName = '/Shimmer loading pages';
+
+  @override
+  State<ShimmerLoadingPage> createState() => _ShimmerLoadingPageState();
+}
+
+class _ShimmerLoadingPageState extends State<ShimmerLoadingPage> {
+  Widget _body = const LoadingContactsIndexPage();
+  String dropdownValue = 'Loading ContactsIndexPage';
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _body,
+      floatingActionButton: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+            icon: const UIcon(UIcons.back_arrow),
+          ),
+          const SizedBox(width: 50),
+          DropdownButton(
+            value: dropdownValue,
+            items: <String>['Loading ContactsIndexPage', 'Two', 'Free', 'Four']
+                .map<DropdownMenuItem<String>>((String value) {
+              return DropdownMenuItem<String>(
+                value: value,
+                child: Text(value),
+              );
+            }).toList(),
+            onChanged: (String? newValue) {
+              Widget currentBody = Center(child: Text(newValue!));
+              if (newValue == 'Loading ContactsIndexPage') {
+                currentBody = const LoadingContactsIndexPage();
+              }
+              setState(() {
+                _body = currentBody;
+                dropdownValue = newValue;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/u_shimmer_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/u_shimmer_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+
+class UShimmerPage extends StatelessWidget {
+  const UShimmerPage({Key? key}) : super(key: key);
+  static const routeName = '/UShimmer';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(routeName.substring(1)),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Text('UShimmer.dark'),
+              UShimmer.dark(
+                  child: URectContainer(
+                height: 20,
+              )),
+              Text('UShimmer.med'),
+              UShimmer.med(
+                  child: URectContainer(
+                height: 20,
+              )),
+              Text('UShimmer.light'),
+              UShimmer.light(
+                  child: URectContainer(
+                height: 20,
+              )),
+              Text('UShimmer.white'),
+              UShimmer.white(
+                  child: URectContainer(
+                height: 20,
+              )),
+            ],
+          ),
+        ));
+  }
+}

--- a/packages/ui_showroom/lib/ui_pages/ui_pages_export.dart
+++ b/packages/ui_showroom/lib/ui_pages/ui_pages_export.dart
@@ -9,3 +9,4 @@ export 'src/dialog_widgets/dialog_widgets_export.dart';
 export 'src/popup_menu_item_widgets/popup_menu_item_widgets_export.dart';
 export 'src/file_widgets/file_widgets_export.dart';
 export 'src/notification_widgets/notifications_widgets_export.dart';
+export 'src/shimmer/shimmer_export.dart';

--- a/packages/ui_showroom/lib/ui_showroom_page.dart
+++ b/packages/ui_showroom/lib/ui_showroom_page.dart
@@ -58,6 +58,7 @@ class UIShowRoomApp extends StatelessWidget {
         UTextInputPage.routeName: (context) => const UTextInputPage(),
         UAccountIDBoxPage.routeName: (context) => const UAccountIDBoxPage(),
         UShimmerPage.routeName: (context) => const UShimmerPage(),
+        ShimmerLoadingPage.routeName: (context) => const ShimmerLoadingPage(),
       },
       home: Scaffold(
         appBar: AppBar(
@@ -246,6 +247,9 @@ class UIShowRoomApp extends StatelessWidget {
                 sessionWidgets: [
                   WidgetPageButton(
                     widgetName: UShimmerPage.routeName,
+                  ),
+                  WidgetPageButton(
+                    widgetName: ShimmerLoadingPage.routeName,
                   ),
                 ],
               ),

--- a/packages/ui_showroom/lib/ui_showroom_page.dart
+++ b/packages/ui_showroom/lib/ui_showroom_page.dart
@@ -57,6 +57,7 @@ class UIShowRoomApp extends StatelessWidget {
         UNotificationsPage.routeName: (context) => const UNotificationsPage(),
         UTextInputPage.routeName: (context) => const UTextInputPage(),
         UAccountIDBoxPage.routeName: (context) => const UAccountIDBoxPage(),
+        UShimmerPage.routeName: (context) => const UShimmerPage(),
       },
       home: Scaffold(
         appBar: AppBar(
@@ -237,6 +238,14 @@ class UIShowRoomApp extends StatelessWidget {
                   ),
                   WidgetPageButton(
                     widgetName: UImageButtonPage.routeName,
+                  ),
+                ],
+              ),
+              const _WidgetsShowSession(
+                sessionTitle: 'Shimmer',
+                sessionWidgets: [
+                  WidgetPageButton(
+                    widgetName: UShimmerPage.routeName,
                   ),
                 ],
               ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR is the start point of all the loading pages of the app. 
[Here](https://www.figma.com/file/RMFzLQgD9RxmSR8Yp4pIqS/Android-MVP?node-id=487%3A27452) is the Figma design for all the loading pages. 

Please note, all the 'no content' type of loading page doesn't need to be developed. Because all the loading pages are used while the app is getting the data from server/backend.  Once the data arrive, we know  how much data we receive(0 or a list of data), which means the app shows a loading page while waiting, and return/show either 'no content' page or data list page after data arrive. 

For example for the  ContactsIndexPage
The loading page will be `Loading State #9 `, after loading is done, it will show either `Contacts #1`(no data) or `Contacts #2`(has data)

![Screen Shot 2022-08-03 at 8 30 16 PM](https://user-images.githubusercontent.com/14248245/182743790-28984c51-c1bd-41b3-9cf3-41ac06b0584f.png)

The 'no content' type of pages include `Loading State #1`,`Loading State #5`,`Loading State #8`

 
In this PR, I have built `UShimmer` widgets and `URectContainer` in the ui library to help build the `LoadingContactsIndexPage`

**How to use `UShimmer` widget?**

`UShimmer` has 4 different colors(dark, med, light, white) so far,  correspond to each color in loading widgets.  

Since the shimmer effect needs a highlight color to make it shining, so I made the following rule for each loading color in Figma.
![image](https://user-images.githubusercontent.com/14248245/182745366-1c00c53c-1f2a-4373-af74-1489460350c6.png)
For the `UShimmer` usage, just use the same color on Figma will be fine. For example, use  `UShimmer.dark `for the loadDark color widgets on Figma. 

Due to most loading widget is a rectangle shape with 4px board radius, so I also created a `URectContainer` to help build the page. 

The following code is to build a shimmer effect(with loadDark color) for a rectangle container.

![image](https://user-images.githubusercontent.com/14248245/182746410-00d827d6-1544-4384-b79f-1f3355ef3863.png)

![Screen Shot 2022-08-03 at 9 00 51 PM](https://user-images.githubusercontent.com/14248245/182746919-3742f0a1-26f2-415b-a6da-372d3390f702.png)


Currently all the loading pages are in the showroom for demo purpose. 

Overall this PR:
1. Add `UShimmer` widgets and `URectContainer` in the ui library and showroom

https://user-images.githubusercontent.com/14248245/182748123-b722eab5-35ee-4237-bd7e-73228717eb8e.mov

2. Add ` LoadingContactsIndexPage` in the showroom

https://user-images.githubusercontent.com/14248245/182753096-5adfdc79-072b-4d5e-a97d-0ce811d1f828.mov

In the App bar area, all the spaces will keep the same as figma, however the width of title part(the following container) will be different base on different width of device.

![Screen Shot 2022-08-03 at 9 53 40 PM](https://user-images.githubusercontent.com/14248245/182753147-eca741ed-6b95-4f88-90ef-4e6a2b1f07d6.png)


The float button in the bottom is for navigating different  loading pages in the showroom, currently only has `LoadingContactsIndexPage`. It is not the part of ` LoadingContactsIndexPage`. 


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
