### PR TITLE
chore(appium): increase AVDlaunchtimeout for CI

### DIFF
--- a/appium-tests/config/wdio.android.ci.conf.ts
+++ b/appium-tests/config/wdio.android.ci.conf.ts
@@ -25,6 +25,7 @@ config.capabilities = [
         //'appium:platformVersion': '12',
         'appium:automationName': 'UiAutomator2',
         'appium:avd': 'android-appium',
+        'appium:avdLaunchTimeout': 120000,
         // The path to the app
         'appium:app': join(process.cwd(), './apps/app-profile.apk'),
         'appium:newCommandTimeout': 240,


### PR DESCRIPTION
## Description
- Increase AVDLaunchTimeout capability for Appium on wdio.android.ci.conf.ts config file to add more time on the AVD emulator launch before running appium and resolve the current issue

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🧪 Tests
- [X] 🗑️ Chore
