### PR TITLE
chore(auth): rename class and minor refactor in auth -UL-182

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -42,7 +42,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.detached) {
-      _warpController.add(DropMultipass());
+      _warpController.add(WarpDropMultipass());
     }
   }
 
@@ -65,6 +65,16 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                   GlobalCupertinoLocalizations.delegate,
                 ],
                 supportedLocales: AppLocalizations.supportedLocales,
+                // home: RepositoryProvider.value(
+                //   value: AuthenticationRepository(),
+                //   child: BlocProvider(
+                //     create: (_) => AppBloc(
+                //       authenticationRepository: _authenticationRepository,
+                //     ),
+                //     child: const AppView(),
+                //   ),
+                // ),
+                /****** */
                 home: BlocBuilder<AuthBloc, AuthState>(
                   bloc: _authController,
                   builder: (context, state) {
@@ -102,11 +112,11 @@ Widget _ifIsSuccess(
       signinDataMap[ULocalKey.isPinStored] == true &&
       signinDataMap[ULocalKey.pinValue] != null) {
     final _pinValue = signinDataMap[ULocalKey.pinValue] as String;
-    _warpController.add(EnableWarp(_pinValue));
+    _warpController.add(WarpStarted(_pinValue));
     return BlocBuilder<WarpBloc, WarpState>(
       bloc: _warpController,
       builder: (context, state) {
-        if (state is WarpStateSuccess) {
+        if (state is WarpLoadSuccess) {
           _currentUserController.add(GetAllUserInfo());
           return const MainBottomNavigationBar();
         }

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -28,7 +28,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
 
   @override
   void initState() {
-    _authController.add(GetAuthKeys());
+    _authController.add(AuthGetPinData());
     WidgetsBinding.instance.addObserver(this);
     super.initState();
   }
@@ -85,7 +85,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                         _currentUserController,
                         _authController,
                       );
-                    } else if (state is GetAuthKeysError) {
+                    } else if (state is AuthLoadFailure) {
                       return const UText(
                         'Unexpected Error Happened',
                         textStyle: UTextStyle.H2_secondaryHeader,

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -65,21 +65,11 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                   GlobalCupertinoLocalizations.delegate,
                 ],
                 supportedLocales: AppLocalizations.supportedLocales,
-                // home: RepositoryProvider.value(
-                //   value: AuthenticationRepository(),
-                //   child: BlocProvider(
-                //     create: (_) => AppBloc(
-                //       authenticationRepository: _authenticationRepository,
-                //     ),
-                //     child: const AppView(),
-                //   ),
-                // ),
-                /****** */
                 home: BlocBuilder<AuthBloc, AuthState>(
                   bloc: _authController,
                   builder: (context, state) {
                     if (state is GetAuthKeysSuccess) {
-                      return _ifIsSuccess(
+                      return _buildEntryPage(
                         state,
                         _warpController,
                         _currentUserController,
@@ -101,7 +91,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
   }
 }
 
-Widget _ifIsSuccess(
+Widget _buildEntryPage(
   GetAuthKeysSuccess state,
   WarpBloc _warpController,
   UpdateCurrentUserBloc _currentUserController,

--- a/lib/auth/data/datasource/auth_local_data.local_datasource.dart
+++ b/lib/auth/data/datasource/auth_local_data.local_datasource.dart
@@ -1,7 +1,7 @@
 import 'package:uplink/utils/services/services_export.dart';
 
-class StoreAuthKeysData {
-  StoreAuthKeysData(this._localStorageService);
+class AuthLocalData {
+  AuthLocalData(this._localStorageService);
   final ULocalStorageService _localStorageService;
 
   Future<void> savePinValue({

--- a/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
+++ b/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
@@ -3,9 +3,9 @@ import 'dart:convert';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 import 'package:uplink/utils/services/warp/warp_service.dart';
 
-class CreateCurrentUserData {
-  CreateCurrentUserData(this._warp);
-  final Warp _warp;
+class WarpCurrentUserData {
+  WarpCurrentUserData(this._warp);
+  final WarpService _warp;
 
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,

--- a/lib/auth/data/repositories/authentication_impl.repository.dart
+++ b/lib/auth/data/repositories/authentication_impl.repository.dart
@@ -1,5 +1,5 @@
-import 'package:uplink/auth/data/datasource/warp_current_user_data.remote_datasource.dart';
 import 'package:uplink/auth/data/datasource/auth_local_data.local_datasource.dart';
+import 'package:uplink/auth/data/datasource/warp_current_user_data.remote_datasource.dart';
 import 'package:uplink/auth/data/repositories/authentication.repository.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 import 'package:uplink/utils/services/services_export.dart';

--- a/lib/auth/data/repositories/authentication_impl.repository.dart
+++ b/lib/auth/data/repositories/authentication_impl.repository.dart
@@ -1,5 +1,5 @@
-import 'package:uplink/auth/data/datasource/create_current_user.remote_datasource.dart';
-import 'package:uplink/auth/data/datasource/store_auth_keys.local_datasource.dart';
+import 'package:uplink/auth/data/datasource/warp_current_user_data.remote_datasource.dart';
+import 'package:uplink/auth/data/datasource/auth_local_data.local_datasource.dart';
 import 'package:uplink/auth/data/repositories/authentication.repository.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 import 'package:uplink/utils/services/services_export.dart';
@@ -10,8 +10,8 @@ class AuthenticationRepositoryImpl implements IAuthenticationRepository {
     this._localDatasource,
   );
 
-  final CreateCurrentUserData _remoteDatasource;
-  final StoreAuthKeysData _localDatasource;
+  final WarpCurrentUserData _remoteDatasource;
+  final AuthLocalData _localDatasource;
 
   @override
   Future<CurrentUser> createCurrentUser({

--- a/lib/auth/presentation/controller/auth_bloc.dart
+++ b/lib/auth/presentation/controller/auth_bloc.dart
@@ -15,9 +15,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   AuthBloc(
     this._repository,
   ) : super(AuthInitial()) {
-    on<CreateNewCurrentUser>((event, emit) async {
+    on<AuthCreateCurrentUser>((event, emit) async {
       try {
-        emit(AuthLoading());
+        emit(AuthLoadInProgress());
         final _currentUser = await _repository.createCurrentUser(
           newUser: event.currentUser,
           password: event.password,
@@ -26,13 +26,13 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           GetAllUserInfo(currentUser: _currentUser),
         );
 
-        emit(AuthSuccess());
+        emit(AuthLoadSuccess());
       } catch (error) {
-        emit(AuthError());
+        emit(AuthLoadFailure(message: 'Failed to create current user'));
       }
     });
 
-    on<SaveAuthKeys>((event, emit) async {
+    on<AuthSetPinData>((event, emit) async {
       try {
         await _repository.savePinValue(
           pinValue: pinValue!,
@@ -41,11 +41,11 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
         await _repository.saveUserIsLoggedValue();
       } catch (error) {
-        emit(SaveAuthKeysError());
+        emit(AuthLoadFailure(message: 'Failed to set local pin data'));
       }
     });
 
-    on<GetAuthKeys>((event, emit) async {
+    on<AuthGetPinData>((event, emit) async {
       try {
         emit(GetAuthKeysLoading());
 
@@ -67,7 +67,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
         emit(GetAuthKeysSuccess(_authKeysMap));
       } catch (error) {
-        emit(GetAuthKeysError());
+        emit(AuthLoadFailure(message: 'Failed to get local pin data'));
       }
     });
   }

--- a/lib/auth/presentation/controller/auth_bloc.dart
+++ b/lib/auth/presentation/controller/auth_bloc.dart
@@ -15,7 +15,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   AuthBloc(
     this._repository,
   ) : super(AuthInitial()) {
-    on<AuthCreateCurrentUser>((event, emit) async {
+    on<AuthSignUp>((event, emit) async {
       try {
         emit(AuthLoadInProgress());
         final _currentUser = await _repository.createCurrentUser(

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -5,9 +5,11 @@ abstract class AuthEvent {
   List<Object> get props => [];
 }
 
-class CreateNewCurrentUser extends AuthEvent {
+class AuthStarted extends AuthEvent {}
+
+class AuthCreateCurrentUser extends AuthEvent {
   // TODO(password): For now the password is empty because it is not working
-  CreateNewCurrentUser({
+  AuthCreateCurrentUser({
     required this.currentUser,
   }) : password = '';
   final CurrentUser currentUser;
@@ -16,9 +18,9 @@ class CreateNewCurrentUser extends AuthEvent {
   List<Object> get props => [currentUser, password];
 }
 
-class SaveAuthKeys extends AuthEvent {}
+class AuthSetPinData extends AuthEvent {}
 
-class GetAuthKeys extends AuthEvent {
+class AuthGetPinData extends AuthEvent {
   @override
   List<Object> get props => [];
 }

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -7,9 +7,9 @@ abstract class AuthEvent {
 
 class AuthStarted extends AuthEvent {}
 
-class AuthCreateCurrentUser extends AuthEvent {
+class AuthSignUp extends AuthEvent {
   // TODO(password): For now the password is empty because it is not working
-  AuthCreateCurrentUser({
+  AuthSignUp({
     required this.currentUser,
   }) : password = '';
   final CurrentUser currentUser;

--- a/lib/auth/presentation/controller/auth_state.dart
+++ b/lib/auth/presentation/controller/auth_state.dart
@@ -7,13 +7,16 @@ abstract class AuthState {
 
 class AuthInitial extends AuthState {}
 
-class AuthLoading extends AuthState {}
+class AuthLoadInProgress extends AuthState {}
 
-class AuthSuccess extends AuthState {}
+class AuthLoadSuccess extends AuthState {}
 
-class AuthError extends AuthState {}
+class AuthLoadFailure extends AuthState {
+  AuthLoadFailure({required this.message});
+  final String message;
+}
 
-class SaveAuthKeysError extends AuthState {}
+// class SaveAuthKeysError extends AuthState {}
 
 class GetAuthKeysLoading extends AuthState {}
 
@@ -26,4 +29,4 @@ class GetAuthKeysSuccess extends AuthState {
   List<Object> get props => [authKeysMap];
 }
 
-class GetAuthKeysError extends AuthState {}
+// class GetAuthKeysError extends AuthState {}

--- a/lib/auth/presentation/controller/auth_state.dart
+++ b/lib/auth/presentation/controller/auth_state.dart
@@ -16,8 +16,6 @@ class AuthLoadFailure extends AuthState {
   final String message;
 }
 
-// class SaveAuthKeysError extends AuthState {}
-
 class GetAuthKeysLoading extends AuthState {}
 
 class GetAuthKeysSuccess extends AuthState {
@@ -28,5 +26,3 @@ class GetAuthKeysSuccess extends AuthState {
   @override
   List<Object> get props => [authKeysMap];
 }
-
-// class GetAuthKeysError extends AuthState {}

--- a/lib/auth/presentation/view/onboard_pin_page.dart
+++ b/lib/auth/presentation/view/onboard_pin_page.dart
@@ -44,7 +44,7 @@ class _OnboardPinPageState extends State<OnboardPinPage> {
                   key: UniqueKey(),
                   pinLength: _pinLength,
                   rightButtonFn: (pin) {
-                    _warp.add(EnableWarp(pin));
+                    _warp.add(WarpStarted(pin));
                     _authController.pinValue = pin;
                     Navigator.of(context).push(
                       MaterialPageRoute<void>(

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -184,7 +184,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
         // TODO(yijing): add loading page
         _authController
           ..add(
-            AuthCreateCurrentUser(
+            AuthSignUp(
               currentUser: CurrentUser.newUser(
                 username: _usernameTextFieldController.text,
                 statusMessage: _messageStatusTextFieldController.text,

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -181,6 +181,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
         Navigator.of(context).pop();
       },
       secondButtonOnPressed: () {
+        // TODO(yijing): add loading page
         _authController
           ..add(
             CreateNewCurrentUser(

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -184,7 +184,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
         // TODO(yijing): add loading page
         _authController
           ..add(
-            CreateNewCurrentUser(
+            AuthCreateCurrentUser(
               currentUser: CurrentUser.newUser(
                 username: _usernameTextFieldController.text,
                 statusMessage: _messageStatusTextFieldController.text,
@@ -193,7 +193,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
             ),
           )
           ..add(
-            SaveAuthKeys(),
+            AuthSetPinData(),
           );
 
         Navigator.of(context).push(

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -85,7 +85,7 @@ class _SigninPageState extends State<SigninPage> {
                           pinLength: 4,
                           rightButtonFn: (pin) {
                             if (pin == widget.authController.pinValue) {
-                              _warpController.add(EnableWarp(pin));
+                              _warpController.add(WarpStarted(pin));
                             }
                           },
                         )

--- a/lib/contacts/add_friend_page/data/datasource/add_friend.remote_datasource.dart
+++ b/lib/contacts/add_friend_page/data/datasource/add_friend.remote_datasource.dart
@@ -7,7 +7,7 @@ import 'package:uplink/utils/services/warp/warp_service.dart';
 
 class AddFriendData {
   AddFriendData(this._warp);
-  final Warp _warp;
+  final WarpService _warp;
 
   Future<User> findUserByDid(String userDid) async {
     try {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:uplink/app/app.dart';
-import 'package:uplink/auth/data/datasource/create_current_user.remote_datasource.dart';
-import 'package:uplink/auth/data/datasource/store_auth_keys.local_datasource.dart';
+import 'package:uplink/auth/data/datasource/auth_local_data.local_datasource.dart';
+import 'package:uplink/auth/data/datasource/warp_current_user_data.remote_datasource.dart';
 import 'package:uplink/auth/data/repositories/authentication.repository.dart';
 import 'package:uplink/auth/data/repositories/authentication_impl.repository.dart';
 import 'package:uplink/auth/presentation/controller/auth_bloc.dart';
@@ -10,9 +10,9 @@ import 'package:uplink/contacts/add_friend_page/data/datasource/add_friend.remot
 import 'package:uplink/contacts/add_friend_page/data/repositories/add_friend_impl.repository.dart';
 import 'package:uplink/contacts/add_friend_page/data/repositories/add_friend_repository.dart';
 import 'package:uplink/contacts/add_friend_page/presentation/controller/add_friend_bloc.dart';
-import 'package:uplink/profile/data/datasource/update_current_user.remote_datasource.dart';
-import 'package:uplink/profile/data/repositories/update_current_user.repository.dart';
-import 'package:uplink/profile/data/repositories/update_current_user_impl.repository.dart';
+import 'package:uplink/profile/data/datasource/user_profile_data.remote_datasource.dart';
+import 'package:uplink/profile/data/repositories/user_profile.repository.dart';
+import 'package:uplink/profile/data/repositories/user_profile_impl.repository.dart';
 import 'package:uplink/profile/presentation/controller/update_current_user_bloc.dart';
 import 'package:uplink/utils/services/services_export.dart';
 import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
@@ -47,7 +47,7 @@ void _registerDependencieAddFriend(GetIt _getIt) {
     )
     ..registerLazySingleton<AddFriendData>(
       () => AddFriendData(
-        Warp(),
+        WarpService(),
       ),
     )
     ..registerLazySingleton<AddFriendBloc>(
@@ -65,13 +65,13 @@ void _registerDependenciesToAuth(GetIt _getIt) {
         _getIt(),
       ),
     )
-    ..registerLazySingleton<CreateCurrentUserData>(
-      () => CreateCurrentUserData(
-        Warp(),
+    ..registerLazySingleton<WarpCurrentUserData>(
+      () => WarpCurrentUserData(
+        WarpService(),
       ),
     )
-    ..registerLazySingleton<StoreAuthKeysData>(
-      () => StoreAuthKeysData(
+    ..registerLazySingleton<AuthLocalData>(
+      () => AuthLocalData(
         ULocalStorageService(),
       ),
     )
@@ -84,14 +84,14 @@ void _registerDependenciesToAuth(GetIt _getIt) {
 
 void _registerDependencieToUpdateCurrentUser(GetIt _getIt) {
   _getIt
-    ..registerLazySingleton<IUpdateCurrentUserRepository>(
-      () => UpdateCurrentUserRepositoryImpl(
+    ..registerLazySingleton<IUserProfileRepository>(
+      () => UserProfileRepositoryImpl(
         _getIt(),
       ),
     )
-    ..registerLazySingleton<UpdateCurrentUserData>(
-      () => UpdateCurrentUserData(
-        Warp(),
+    ..registerLazySingleton<UserProfileData>(
+      () => UserProfileData(
+        WarpService(),
       ),
     )
     ..registerLazySingleton<UpdateCurrentUserBloc>(

--- a/lib/profile/data/datasource/user_profile_data.remote_datasource.dart
+++ b/lib/profile/data/datasource/user_profile_data.remote_datasource.dart
@@ -5,9 +5,9 @@ import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 import 'package:uplink/utils/services/warp/warp_service.dart';
 
-class UpdateCurrentUserData {
-  UpdateCurrentUserData(this._warp);
-  final Warp _warp;
+class UserProfileData {
+  UserProfileData(this._warp);
+  final WarpService _warp;
 
   Future<CurrentUser> getCurrentUserInfo() async {
     try {

--- a/lib/profile/data/repositories/user_profile.repository.dart
+++ b/lib/profile/data/repositories/user_profile.repository.dart
@@ -1,6 +1,6 @@
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 
-abstract class IUpdateCurrentUserRepository {
+abstract class IUserProfileRepository {
   Future<CurrentUser> getCurrentUserInfo();
 
   String getDid();

--- a/lib/profile/data/repositories/user_profile_impl.repository.dart
+++ b/lib/profile/data/repositories/user_profile_impl.repository.dart
@@ -1,11 +1,11 @@
-import 'package:uplink/profile/data/datasource/update_current_user.remote_datasource.dart';
-import 'package:uplink/profile/data/repositories/update_current_user.repository.dart';
+import 'package:uplink/profile/data/datasource/user_profile_data.remote_datasource.dart';
+import 'package:uplink/profile/data/repositories/user_profile.repository.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 
-class UpdateCurrentUserRepositoryImpl implements IUpdateCurrentUserRepository {
-  const UpdateCurrentUserRepositoryImpl(this._remoteDatasource);
+class UserProfileRepositoryImpl implements IUserProfileRepository {
+  const UserProfileRepositoryImpl(this._remoteDatasource);
 
-  final UpdateCurrentUserData _remoteDatasource;
+  final UserProfileData _remoteDatasource;
 
   @override
   Future<CurrentUser> getCurrentUserInfo() {

--- a/lib/profile/presentation/controller/update_current_user_bloc.dart
+++ b/lib/profile/presentation/controller/update_current_user_bloc.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
-import 'package:uplink/profile/data/repositories/update_current_user.repository.dart';
+import 'package:uplink/profile/data/repositories/user_profile.repository.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 
 part 'update_current_user_event.dart';
@@ -204,5 +204,5 @@ class UpdateCurrentUserBloc
   }
   CurrentUser? currentUser = const CurrentUser.newUser(username: '');
 
-  final IUpdateCurrentUserRepository _updateCurrentUserRepository;
+  final IUserProfileRepository _updateCurrentUserRepository;
 }

--- a/lib/utils/services/local_storage_service.dart
+++ b/lib/utils/services/local_storage_service.dart
@@ -2,7 +2,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 enum ULocalKey { isUserLogged, isPinStored, pinValue }
 
-//TODO(yijing): update with HydratedBloc
 class ULocalStorageService {
   Future<void> saveStringValue({
     required ULocalKey localKey,

--- a/lib/utils/services/local_storage_service.dart
+++ b/lib/utils/services/local_storage_service.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 enum ULocalKey { isUserLogged, isPinStored, pinValue }
 
+//TODO(yijing): update with HydratedBloc
 class ULocalStorageService {
   Future<void> saveStringValue({
     required ULocalKey localKey,

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -11,11 +11,11 @@ part 'warp_state.dart';
 enum MultipassTest { temporary, persistent }
 
 class WarpBloc extends Bloc<WarpEvent, WarpState> {
-  WarpBloc() : super(WarpStateInitial()) {
-    on<EnableWarp>((event, emit) async {
+  WarpBloc() : super(WarpInitial()) {
+    on<WarpStarted>((event, emit) async {
       try {
         if (_tesseract == null || multipass == null) {
-          emit(WarpStateLoading());
+          emit(WarpLoadInProgress());
           await _definePathToTesseractAndMultipass();
           await _checkIfTesseractExists(event.passphrase);
 
@@ -24,21 +24,21 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
             _multipassPath!,
           );
 
-          emit(WarpStateSuccess());
+          emit(WarpLoadSuccess());
         }
       } catch (error) {
-        emit(WarpStateError());
+        emit(WarpLoadFailure());
         addError(error);
       }
     });
 
-    on<DropMultipass>((event, emit) async {
+    on<WarpDropMultipass>((event, emit) async {
       try {
-        emit(WarpStateLoading());
+        emit(WarpLoadInProgress());
         multipass!.drop();
-        emit(WarpStateSuccess());
+        emit(WarpLoadSuccess());
       } catch (error) {
-        emit(WarpStateError());
+        emit(WarpLoadFailure());
         addError(error);
       }
     });

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -76,8 +76,6 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
 
   warp_multipass.MultiPass? multipass;
 
-  late warp.DID? currentUserDID;
-
   String? _tesseractPath;
 
   String? _multipassPath;

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -16,8 +16,8 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
       try {
         if (_tesseract == null || multipass == null) {
           emit(WarpLoadInProgress());
-          await _definePathToTesseractAndMultipass();
-          await _checkIfTesseractExists(event.passphrase);
+          await _getPathOfTesseractAndMultipass();
+          await _getTesseract(event.pin);
 
           multipass = warp_mp_ipfs.multipass_ipfs_persistent(
             _tesseract!,
@@ -44,9 +44,8 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
     });
   }
 
-  // Define Tesseract path and file name to save
-  // Define Multipass path to save
-  Future<void> _definePathToTesseractAndMultipass() async {
+  /// Get the file path to save tesseract and multipass
+  Future<void> _getPathOfTesseractAndMultipass() async {
     final _directory = await path_provider.getApplicationSupportDirectory();
     _multipassPath = _directory.path;
     _tesseractPath = '${_directory.path}/tesseract';
@@ -56,25 +55,21 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
   // Unlock Tesseract using pin as passphrase
   // Save a file for Tesseract
   // Set auto save
-  Future<void> _enableTesseract(String passphrase) async {
+  Future<void> _enableTesseract(String pin) async {
     _tesseract!
-      ..unlock(passphrase)
+      ..unlock(pin)
       ..setFile(_tesseractPath!)
       ..setAutosave();
   }
 
-  // It check is there is a tesseract instance in the device
-  // If not, it will create a new one
-  Future<bool> _checkIfTesseractExists(String passphrase) async {
+  /// Get Tesseract from the devive. If not, create a new one
+  Future<void> _getTesseract(String pin) async {
     try {
       _tesseract = warp.Tesseract.fromFile(_tesseractPath!);
-      await _enableTesseract(passphrase);
-      return true;
     } catch (error) {
       _tesseract = warp.Tesseract.newStore();
-      await _enableTesseract(passphrase);
-      return false;
     }
+    await _enableTesseract(pin);
   }
 
   warp.Tesseract? _tesseract;

--- a/lib/utils/services/warp/controller/warp_event.dart
+++ b/lib/utils/services/warp/controller/warp_event.dart
@@ -5,22 +5,22 @@ abstract class WarpEvent {
   List<Object> get props => [];
 }
 
-class EnableWarp extends WarpEvent {
-  EnableWarp(this.passphrase);
+class WarpStarted extends WarpEvent {
+  WarpStarted(this.passphrase);
 
   final String passphrase;
   @override
   List<Object> get props => [];
 }
 
-class DropMultipass extends WarpEvent {
-  DropMultipass();
+class WarpDropMultipass extends WarpEvent {
+  WarpDropMultipass();
 
   @override
   List<Object> get props => [];
 }
 
-class GetUserDID extends WarpEvent {
-  @override
-  List<Object> get props => [];
-}
+// class WarpGetUserDID extends WarpEvent {
+//   @override
+//   List<Object> get props => [];
+// }

--- a/lib/utils/services/warp/controller/warp_event.dart
+++ b/lib/utils/services/warp/controller/warp_event.dart
@@ -6,9 +6,9 @@ abstract class WarpEvent {
 }
 
 class WarpStarted extends WarpEvent {
-  WarpStarted(this.passphrase);
+  WarpStarted(this.pin);
 
-  final String passphrase;
+  final String pin;
   @override
   List<Object> get props => [];
 }

--- a/lib/utils/services/warp/controller/warp_state.dart
+++ b/lib/utils/services/warp/controller/warp_state.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_late_for_private_fields_and_variables
+
 part of 'warp_bloc.dart';
 
 @immutable

--- a/lib/utils/services/warp/controller/warp_state.dart
+++ b/lib/utils/services/warp/controller/warp_state.dart
@@ -1,14 +1,12 @@
-// ignore_for_file: use_late_for_private_fields_and_variables
-
 part of 'warp_bloc.dart';
 
 @immutable
 abstract class WarpState {}
 
-class WarpStateInitial extends WarpState {}
+class WarpInitial extends WarpState {}
 
-class WarpStateLoading extends WarpState {}
+class WarpLoadInProgress extends WarpState {}
 
-class WarpStateSuccess extends WarpState {}
+class WarpLoadSuccess extends WarpState {}
 
-class WarpStateError extends WarpState {}
+class WarpLoadFailure extends WarpState {}

--- a/lib/utils/services/warp/warp_service.dart
+++ b/lib/utils/services/warp/warp_service.dart
@@ -5,8 +5,8 @@ import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
 import 'package:warp_dart/multipass.dart' as multipass;
 import 'package:warp_dart/warp.dart';
 
-class Warp {
-  final _warp = GetIt.I.get<WarpBloc>();
+class WarpService {
+  final _warpBloc = GetIt.I.get<WarpBloc>();
 
   Future<String> createUser({
     required String username,
@@ -15,11 +15,11 @@ class Warp {
     required String base64Image,
   }) async {
     try {
-      _warp.currentUserDID =
-          _warp.multipass?.createIdentity(username.trim(), password);
+      _warpBloc.currentUserDID =
+          _warpBloc.multipass?.createIdentity(username.trim(), password);
       changeMessageStatus(messageStatus);
       changeProfilePicture(base64Image);
-      return _warp.currentUserDID.toString().replaceAll('did:key:', '');
+      return _warpBloc.currentUserDID.toString().replaceAll('did:key:', '');
     } catch (error) {
       throw Exception(error);
     }
@@ -27,7 +27,7 @@ class Warp {
 
   Map<String, dynamic> getCurrentUserInfo() {
     try {
-      final _currentUserIdentity = _warp.multipass!.getOwnIdentity();
+      final _currentUserIdentity = _warpBloc.multipass!.getOwnIdentity();
       final _currentUserMap = {
         'did':
             _currentUserIdentity.did_key.toString().replaceAll('did:key:', ''),
@@ -44,7 +44,7 @@ class Warp {
 
   String getDid() {
     try {
-      final _did = _warp.multipass!.getOwnIdentity().did_key.toString();
+      final _did = _warpBloc.multipass!.getOwnIdentity().did_key.toString();
       return _did.replaceAll('did:key:', '');
     } catch (error) {
       throw Exception(error);
@@ -53,7 +53,7 @@ class Warp {
 
   String getUsername() {
     try {
-      final _username = _warp.multipass!.getOwnIdentity().username;
+      final _username = _warpBloc.multipass!.getOwnIdentity().username;
       return _username;
     } catch (error) {
       throw Exception(error);
@@ -62,7 +62,7 @@ class Warp {
 
   String getMessageStatus() {
     try {
-      return _warp.multipass!.getOwnIdentity().status_message!;
+      return _warpBloc.multipass!.getOwnIdentity().status_message!;
     } catch (error) {
       throw Exception(error);
     }
@@ -72,7 +72,7 @@ class Warp {
     try {
       final _identityUpdated =
           multipass.IdentityUpdate.setUsername(newUserName.trim());
-      _warp.multipass!.updateIdentity(_identityUpdated);
+      _warpBloc.multipass!.updateIdentity(_identityUpdated);
       return getUsername();
     } catch (error) {
       throw Exception(error);
@@ -84,7 +84,7 @@ class Warp {
       final _identityUpdated =
           multipass.IdentityUpdate.setStatusMessage(newStatus.trim());
 
-      _warp.multipass!.updateIdentity(_identityUpdated);
+      _warpBloc.multipass!.updateIdentity(_identityUpdated);
       return getMessageStatus();
     } catch (error) {
       throw Exception(error);
@@ -94,7 +94,7 @@ class Warp {
   String getProfilePicture() {
     try {
       final _profilePictureBase64String =
-          _warp.multipass!.getOwnIdentity().graphics.profile_picture;
+          _warpBloc.multipass!.getOwnIdentity().graphics.profile_picture;
       return _profilePictureBase64String;
     } catch (error) {
       throw Exception(error);
@@ -105,7 +105,7 @@ class Warp {
     try {
       final _identityUpdated =
           multipass.IdentityUpdate.setPicture(_base64Image);
-      _warp.multipass!.updateIdentity(_identityUpdated);
+      _warpBloc.multipass!.updateIdentity(_identityUpdated);
       return getProfilePicture();
     } catch (error) {
       throw Exception(error);
@@ -115,7 +115,7 @@ class Warp {
   String getBannerPicture() {
     try {
       final _bannerPictureBase64String =
-          _warp.multipass!.getOwnIdentity().graphics.profile_banner;
+          _warpBloc.multipass!.getOwnIdentity().graphics.profile_banner;
       return _bannerPictureBase64String;
     } on WarpException {
       throw Exception(['WARP_EXCEPTION', 'get_banner_picture']);
@@ -127,7 +127,7 @@ class Warp {
   String changeBannerPicture(String _base64Image) {
     try {
       final _identityUpdated = multipass.IdentityUpdate.setBanner(_base64Image);
-      _warp.multipass!.updateIdentity(_identityUpdated);
+      _warpBloc.multipass!.updateIdentity(_identityUpdated);
       return getBannerPicture();
     } on WarpException {
       throw Exception(['WARP_EXCEPTION', 'update_banner_picture']);
@@ -138,7 +138,7 @@ class Warp {
 
   Map<String, dynamic> findUserByDid(String _userDid) {
     try {
-      final _userIdentity = _warp.multipass!.getIdentityByDID(
+      final _userIdentity = _warpBloc.multipass!.getIdentityByDID(
         'did:key:$_userDid',
       );
       final _userMap = {

--- a/lib/utils/services/warp/warp_service.dart
+++ b/lib/utils/services/warp/warp_service.dart
@@ -8,6 +8,8 @@ import 'package:warp_dart/warp.dart';
 class WarpService {
   final _warpBloc = GetIt.I.get<WarpBloc>();
 
+  late DID? currentUserDID;
+
   Future<String> createUser({
     required String username,
     required String messageStatus,
@@ -15,11 +17,11 @@ class WarpService {
     required String base64Image,
   }) async {
     try {
-      _warpBloc.currentUserDID =
+      currentUserDID =
           _warpBloc.multipass?.createIdentity(username.trim(), password);
       changeMessageStatus(messageStatus);
       changeProfilePicture(base64Image);
-      return _warpBloc.currentUserDID.toString().replaceAll('did:key:', '');
+      return currentUserDID.toString().replaceAll('did:key:', '');
     } catch (error) {
       throw Exception(error);
     }

--- a/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_profile_index_page.dart
+++ b/packages/ui_showroom/lib/ui_pages/src/shimmer/loading_pages/loading_profile_index_page.dart
@@ -19,41 +19,41 @@ class LoadingProfileIndexPage extends StatelessWidget {
             ],
           ),
         ),
-        SizedBox(height: 20),
+        const SizedBox(height: 20),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Column(
             children: [
-              UShimmer.med(child: URectContainer(height: 21)),
-              SizedBox(height: 4),
-              UShimmer.dark(
+              const UShimmer.med(child: URectContainer(height: 21)),
+              const SizedBox(height: 4),
+              const UShimmer.dark(
                 child: URectContainer(height: 18),
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               UShimmer.med(
                   child: URectContainer(
                 height: 40,
                 bordRadius: BorderRadius.circular(50),
               )),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
                     child: Column(
                       children: [
-                        UShimmer.dark(
+                        const UShimmer.dark(
                           child: URectContainer(height: 15),
                         ),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             ...List.generate(
                                 3,
-                                (index) => Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                          horizontal: 2),
+                                (index) => const Padding(
+                                      padding:
+                                          EdgeInsets.symmetric(horizontal: 2),
                                       child: UShimmer.light(
                                           child: URectContainer(
                                               height: 24, width: 24)),
@@ -63,10 +63,10 @@ class LoadingProfileIndexPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                  SizedBox(width: 8),
+                  const SizedBox(width: 8),
                   Expanded(
                     child: Column(
-                      children: [
+                      children: const [
                         UShimmer.dark(
                           child: URectContainer(height: 15),
                         ),
@@ -77,10 +77,10 @@ class LoadingProfileIndexPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                  SizedBox(width: 8),
+                  const SizedBox(width: 8),
                   Expanded(
                     child: Column(
-                      children: [
+                      children: const [
                         UShimmer.dark(
                           child: URectContainer(height: 15),
                         ),
@@ -96,14 +96,14 @@ class LoadingProfileIndexPage extends StatelessWidget {
             ],
           ),
         ),
-        SizedBox(
+        const SizedBox(
           height: 24,
         ),
-        UDivider(),
+        const UDivider(),
         Padding(
-          padding: EdgeInsets.fromLTRB(16, 16, 16, 24),
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
           child: Column(
-            children: [
+            children: const [
               UShimmer.dark(
                   child: URectContainer(
                 height: 24,
@@ -118,15 +118,15 @@ class LoadingProfileIndexPage extends StatelessWidget {
             ],
           ),
         ),
-        UDivider(),
+        const UDivider(),
         Expanded(
           child: ListView.separated(
             padding: EdgeInsets.zero,
             physics: const NeverScrollableScrollPhysics(),
             separatorBuilder: (context, index) => const UDivider(),
-            itemBuilder: (context, index) => UShimmer.dark(
+            itemBuilder: (context, index) => const UShimmer.dark(
               child: Padding(
-                padding: const EdgeInsets.all(16),
+                padding: EdgeInsets.all(16),
                 child: URectContainer(height: 24),
               ),
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
I made some renaming and minor refactor mainly under the auth folder. 

1. Rename the bloc to follow the naming conventions below. 
https://bloclibrary.dev/#/blocnamingconventions
For event:
`BlocSubject + Noun (optional) + Verb (event)`
Initial load events is `BlocSubject + Started`
I didn't name the events as past tense, but I can do it if you are good with it. 
For state:
`BlocSubject + Verb (action) + State(one of the following state)`
Initial | Success | Failure | InProgress

2. Change name from warp to warpService, and move DID from warpBLoc to warpService.
In order to distinguish data model we used in the app and service class we used to get data, I added 'Service' in the end of  warp and DID is only used in warpService, so I moved it from warpBloc.

3. Rename class to noun instead of start with verb. 

4. Add message parameter in the failure state, so anything wrong will trigger the failure state, in the same time, we can know where it come from.

Please review the code to see detail  changes. This PR is not intent to change any feature or UI, please let me know if you have any problem. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🧹 Code refactor

