### PR TITLE
feat(OnboardCreateProfilePage): add loading page in signup(create account)

### DIFF
--- a/lib/auth/presentation/view/linking_satellites_page.dart
+++ b/lib/auth/presentation/view/linking_satellites_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:ui_library/ui_library_export.dart';
+
+class LinkingSatellitesPage extends StatefulWidget {
+  const LinkingSatellitesPage({Key? key}) : super(key: key);
+
+  @override
+  State<LinkingSatellitesPage> createState() => _LinkingSatellitesPageState();
+}
+
+class _LinkingSatellitesPageState extends State<LinkingSatellitesPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 15),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const <Widget>[
+              ULoadingIndicator(
+                padding: EdgeInsets.zero,
+              ),
+              UText(
+                'Linking Satellites...',
+                textStyle: UTextStyle.H1_primaryHeader,
+              ),
+              SizedBox.square(
+                dimension: 20,
+              ),
+              UText(
+                'Making contact, requesting entry to Realm...',
+                textStyle: UTextStyle.B1_body,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -5,6 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:get_it/get_it.dart';
 import 'package:ui_library/ui_library_export.dart';
 import 'package:uplink/auth/presentation/controller/auth_bloc.dart';
+import 'package:uplink/auth/presentation/view/linking_satellites_page.dart';
 import 'package:uplink/l10n/main_app_strings.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
 import 'package:uplink/utils/ui_utils/bottom_navigation_bar.dart';
@@ -26,6 +29,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
   final _usernameTextFieldController = TextEditingController();
   final _messageStatusTextFieldController = TextEditingController();
   File? _userPicture;
+  bool _isSigningUp = false;
 
   void _dismissKeyboard() => FocusManager.instance.primaryFocus?.unfocus();
 
@@ -57,103 +61,108 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: _dismissKeyboard,
-      child: Scaffold(
-        resizeToAvoidBottomInset: false,
-        appBar: UAppBar.back(
-          title: UAppStrings.createProfilePage_appBarTitle,
-        ),
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
-            child: SingleChildScrollView(
-              controller: _scrollController,
-              reverse: true,
-              physics: const BouncingScrollPhysics(),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const SizedBox(height: 16),
-                  const UText(
-                    UAppStrings.createProfilePage_description,
-                    textStyle: UTextStyle.B1_body,
-                  ),
-                  const SizedBox(height: 40),
-                  Align(
-                    child: UUserPictureChange(
-                      uImage: UImage(
-                        imagePath: _userPicture?.path,
-                        imageSource: ImageSource.file,
-                      ),
-                      onPictureSelected: (pictureSelected) {
-                        setState(() {
-                          _userPicture = pictureSelected;
-                        });
-                      },
+    return _isSigningUp == true
+        ? const LinkingSatellitesPage()
+        : GestureDetector(
+            onTap: _dismissKeyboard,
+            child: Scaffold(
+              resizeToAvoidBottomInset: false,
+              appBar: UAppBar.back(
+                title: UAppStrings.createProfilePage_appBarTitle,
+              ),
+              body: SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+                  child: SingleChildScrollView(
+                    controller: _scrollController,
+                    reverse: true,
+                    physics: const BouncingScrollPhysics(),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const SizedBox(height: 16),
+                        const UText(
+                          UAppStrings.createProfilePage_description,
+                          textStyle: UTextStyle.B1_body,
+                        ),
+                        const SizedBox(height: 40),
+                        Align(
+                          child: UUserPictureChange(
+                            uImage: UImage(
+                              imagePath: _userPicture?.path,
+                              imageSource: ImageSource.file,
+                            ),
+                            onPictureSelected: (pictureSelected) {
+                              setState(() {
+                                _userPicture = pictureSelected;
+                              });
+                            },
+                          ),
+                        ),
+                        const SizedBox(height: 56),
+                        UTextInput.singleLineWithTitle(
+                          key: _uTextInputStateForUsernameField,
+                          controller: _usernameTextFieldController,
+                          uTextInputRules: UTextInputRules.username,
+                          textFieldTitle: UAppStrings
+                              .createProfilePage_usernameTextFieldTitle,
+                          hintText: UAppStrings
+                              .createProfilePage_usernameTextFieldHintText,
+                          onChanged: (value) {
+                            value.isNotEmpty
+                                ? _isSignInButtonEnabled.value = true
+                                : _isSignInButtonEnabled.value = false;
+                          },
+                        ),
+                        const SizedBox.square(dimension: 24),
+                        UTextInput.singleLineWithTitle(
+                          key: _uTextInputStateForMessageStatusField,
+                          controller: _messageStatusTextFieldController,
+                          uTextInputRules: UTextInputRules.messageStatus,
+                          textFieldTitle: UAppStrings
+                              .createProfilePage_statusMessageTextFieldTitle,
+                          hintText: UAppStrings
+                              .createProfilePage_statusMessageTextFieldHintText,
+                          onChanged: (value) {},
+                        ),
+                        const SizedBox.square(dimension: 56),
+                        ValueListenableBuilder(
+                          valueListenable: _isSignInButtonEnabled,
+                          builder: (context, object, widget) {
+                            return UButton.primary(
+                              label: UAppStrings.createProfilePage_signinButton,
+                              disabled: !_isSignInButtonEnabled.value,
+                              uIconData: UIcons.friend_added,
+                              onPressed: () async {
+                                if (_usernameTextFieldController
+                                        .text.isNotEmpty &&
+                                    _usernameTextFieldController.text.length <
+                                        5) {
+                                  _uTextInputStateForUsernameField.currentState!
+                                      .startCheckingShortUsernameError();
+                                } else if (_usernameTextFieldController
+                                        .text.length >=
+                                    5) {
+                                  await _callBottomSheets();
+                                }
+                              },
+                            );
+                          },
+                        ),
+                        AnimatedPadding(
+                          duration: const Duration(milliseconds: 50),
+                          curve: Curves.easeInOut,
+                          padding: EdgeInsets.only(
+                            bottom: MediaQuery.of(context).viewInsets.bottom,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(height: 56),
-                  UTextInput.singleLineWithTitle(
-                    key: _uTextInputStateForUsernameField,
-                    controller: _usernameTextFieldController,
-                    uTextInputRules: UTextInputRules.username,
-                    textFieldTitle:
-                        UAppStrings.createProfilePage_usernameTextFieldTitle,
-                    hintText:
-                        UAppStrings.createProfilePage_usernameTextFieldHintText,
-                    onChanged: (value) {
-                      value.isNotEmpty
-                          ? _isSignInButtonEnabled.value = true
-                          : _isSignInButtonEnabled.value = false;
-                    },
-                  ),
-                  const SizedBox.square(dimension: 24),
-                  UTextInput.singleLineWithTitle(
-                    key: _uTextInputStateForMessageStatusField,
-                    controller: _messageStatusTextFieldController,
-                    uTextInputRules: UTextInputRules.messageStatus,
-                    textFieldTitle: UAppStrings
-                        .createProfilePage_statusMessageTextFieldTitle,
-                    hintText: UAppStrings
-                        .createProfilePage_statusMessageTextFieldHintText,
-                    onChanged: (value) {},
-                  ),
-                  const SizedBox.square(dimension: 56),
-                  ValueListenableBuilder(
-                    valueListenable: _isSignInButtonEnabled,
-                    builder: (context, object, widget) {
-                      return UButton.primary(
-                        label: UAppStrings.createProfilePage_signinButton,
-                        disabled: !_isSignInButtonEnabled.value,
-                        uIconData: UIcons.friend_added,
-                        onPressed: () async {
-                          if (_usernameTextFieldController.text.isNotEmpty &&
-                              _usernameTextFieldController.text.length < 5) {
-                            _uTextInputStateForUsernameField.currentState!
-                                .startCheckingShortUsernameError();
-                          } else if (_usernameTextFieldController.text.length >=
-                              5) {
-                            await _callBottomSheets();
-                          }
-                        },
-                      );
-                    },
-                  ),
-                  AnimatedPadding(
-                    duration: const Duration(milliseconds: 50),
-                    curve: Curves.easeInOut,
-                    padding: EdgeInsets.only(
-                      bottom: MediaQuery.of(context).viewInsets.bottom,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        ),
-      ),
-    );
+          );
   }
 
   Future<void> _callBottomSheets() async {
@@ -180,28 +189,36 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
       firstButtonOnPressed: () async {
         Navigator.of(context).pop();
       },
-      secondButtonOnPressed: () {
-        // TODO(yijing): add loading page
-        _authController
-          ..add(
-            AuthSignUp(
-              currentUser: CurrentUser.newUser(
-                username: _usernameTextFieldController.text,
-                statusMessage: _messageStatusTextFieldController.text,
-                profilePicture: _userPicture,
-              ),
-            ),
-          )
-          ..add(
-            AuthSetPinData(),
-          );
+      secondButtonOnPressed: () async {
+        setState(() {
+          Navigator.of(context).pop(); //close bottom sheet
+          _isSigningUp = true;
+        });
 
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => const MainBottomNavigationBar(),
+        await signUpAndSetPinData().whenComplete(
+          () => Navigator.of(context).pushReplacement(
+            MaterialPageRoute<void>(
+              builder: (context) => const MainBottomNavigationBar(),
+            ),
           ),
         );
       },
     ).show();
+  }
+
+  Future<void> signUpAndSetPinData() async {
+    _authController
+      ..add(
+        AuthSignUp(
+          currentUser: CurrentUser.newUser(
+            username: _usernameTextFieldController.text,
+            statusMessage: _messageStatusTextFieldController.text,
+            profilePicture: _userPicture,
+          ),
+        ),
+      )
+      ..add(
+        AuthSetPinData(),
+      );
   }
 }

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -6,7 +6,6 @@ import 'package:get_it/get_it.dart';
 import 'package:ui_library/ui_library_export.dart';
 import 'package:uplink/auth/presentation/controller/auth_bloc.dart';
 import 'package:uplink/l10n/main_app_strings.dart';
-import 'package:uplink/profile/presentation/controller/update_current_user_bloc.dart';
 import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
 import 'package:uplink/utils/utils_export.dart';
 
@@ -24,7 +23,6 @@ class SigninPage extends StatefulWidget {
 
 class _SigninPageState extends State<SigninPage> {
   final _warpController = GetIt.I.get<WarpBloc>();
-  final _updateCurrentUserController = GetIt.I.get<UpdateCurrentUserBloc>();
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -98,8 +98,7 @@ class _SigninPageState extends State<SigninPage> {
                           child: const SizedBox.shrink(),
                         ),
                   listener: (context, state) {
-                    if (_warpController.multipass != null) {
-                      _updateCurrentUserController.add(GetAllUserInfo());
+                    if (state is WarpLoadSuccess) {
                       Navigator.of(context).pushAndRemoveUntil(
                         MaterialPageRoute<void>(
                           builder: (context) => const MainBottomNavigationBar(),

--- a/lib/auth/presentation/view/view_export.dart
+++ b/lib/auth/presentation/view/view_export.dart
@@ -1,3 +1,4 @@
+export 'linking_satellites_page.dart';
 export 'onboard_create_account_page.dart';
 export 'onboard_import_account_page/onboard_import_account_page.dart';
 export 'onboard_pin_page.dart';

--- a/lib/profile/presentation/controller/update_current_user_bloc.dart
+++ b/lib/profile/presentation/controller/update_current_user_bloc.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:uplink/profile/data/repositories/user_profile.repository.dart';

--- a/lib/profile/presentation/controller/update_current_user_state.dart
+++ b/lib/profile/presentation/controller/update_current_user_state.dart
@@ -1,7 +1,8 @@
 part of 'update_current_user_bloc.dart';
 
 @immutable
-abstract class UpdateCurrentUserState {
+abstract class UpdateCurrentUserState extends Equatable {
+  @override
   List<Object> get props => [];
 }
 

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:warp_dart/mp_ipfs.dart' as warp_mp_ipfs;

--- a/lib/utils/services/warp/controller/warp_state.dart
+++ b/lib/utils/services/warp/controller/warp_state.dart
@@ -3,12 +3,24 @@
 part of 'warp_bloc.dart';
 
 @immutable
-abstract class WarpState {}
+abstract class WarpState extends Equatable {}
 
-class WarpInitial extends WarpState {}
+class WarpInitial extends WarpState {
+  @override
+  List<Object?> get props => [];
+}
 
-class WarpLoadInProgress extends WarpState {}
+class WarpLoadInProgress extends WarpState {
+  @override
+  List<Object?> get props => [];
+}
 
-class WarpLoadSuccess extends WarpState {}
+class WarpLoadSuccess extends WarpState {
+  @override
+  List<Object?> get props => [];
+}
 
-class WarpLoadFailure extends WarpState {}
+class WarpLoadFailure extends WarpState {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/utils/services/warp/warp_service.dart
+++ b/lib/utils/services/warp/warp_service.dart
@@ -8,8 +8,6 @@ import 'package:warp_dart/warp.dart';
 class WarpService {
   final _warpBloc = GetIt.I.get<WarpBloc>();
 
-  late DID? currentUserDID;
-
   Future<String> createUser({
     required String username,
     required String messageStatus,
@@ -17,11 +15,11 @@ class WarpService {
     required String base64Image,
   }) async {
     try {
-      currentUserDID =
+      final _currentUserDID =
           _warpBloc.multipass?.createIdentity(username.trim(), password);
       changeMessageStatus(messageStatus);
       changeProfilePicture(base64Image);
-      return currentUserDID.toString().replaceAll('did:key:', '');
+      return _currentUserDID.toString().replaceAll('did:key:', '');
     } catch (error) {
       throw Exception(error);
     }

--- a/lib/utils/ui_utils/bottom_navigation_bar.dart
+++ b/lib/utils/ui_utils/bottom_navigation_bar.dart
@@ -44,7 +44,7 @@ class _MainBottomNavigationBarState extends State<MainBottomNavigationBar> {
   @override
   void initState() {
     super.initState();
-    // TODO（yijing)：add loading page for this call
+    // TODO(yijing): add loading page for this call
     _controller.add(GetAllUserInfo());
   }
 

--- a/lib/utils/ui_utils/bottom_navigation_bar.dart
+++ b/lib/utils/ui_utils/bottom_navigation_bar.dart
@@ -42,6 +42,13 @@ class _MainBottomNavigationBarState extends State<MainBottomNavigationBar> {
   final _controller = GetIt.I.get<UpdateCurrentUserBloc>();
 
   @override
+  void initState() {
+    super.initState();
+    // TODO（yijing)：add loading page for this call
+    _controller.add(GetAllUserInfo());
+  }
+
+  @override
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
1. This PR is to add loading page(LinkingSatellitesPage) in OnboardCreateProfilePage(the final page to create an account).
The loading page may appear in a very short time if creating account process is fast enough.  
In order to show the whole picture of how loading page looks like.  I add 3 seconds delay before creating an account in the following video.  The real app usually won't show loading page for a long time. 

https://user-images.githubusercontent.com/14248245/188193445-edda6fbd-caa4-453a-8f51-655ef8bdd0eb.mov

If you want to reproduce the situation in this video, you can add the following highlighted code in `lib/auth/presentation/view/onboarding_create_profile_page.dart` to delay the signin process. 

![for test](https://user-images.githubusercontent.com/14248245/188194061-e1491dc8-c0b4-4bab-857e-1204063b61fc.png)

Please note: I didn't add loading page in the sign in page, because I found a freeze issue in `Navigator`.  If we want to navigate the page base on the changes of `BlocState` , the screen will freeze a moment before going to the next page. the detail is in [this UL-183 Jira ticket](https://satellite-im.atlassian.net/browse/UL-183?atlOrigin=eyJpIjoiMmFiN2Q5MjkyYjQzNDk0YzkwZTQ1NGFkNzAyZTg0YjMiLCJwIjoiaiJ9)

Since the previous signin process is swift, so I didn't add loading page to make the freeze issue too obvious.   



2. Move the `GetAllUserInfo` from `onboarding_create_profile_page` to `bottom_navigation_bar` to make it faster going to the home page. It will get the user info in the home page instead of before go into the home page. 
![image](https://user-images.githubusercontent.com/14248245/188196090-d44ad5d2-a6c1-44bc-8dbd-4153a8f89124.png)



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
