### PR TITLE
add(OnboardRecoverySeedPage): implement recovery seeds from warp

### DIFF
--- a/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
+++ b/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
@@ -10,7 +10,7 @@ class WarpCurrentUserData {
 
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? passphrase,
+    required String passphrase,
   }) async {
     try {
       String? _imageFileConvertedToBase64;

--- a/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
+++ b/lib/auth/data/datasource/warp_current_user_data.remote_datasource.dart
@@ -10,7 +10,7 @@ class WarpCurrentUserData {
 
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? password,
+    required String? passphrase,
   }) async {
     try {
       String? _imageFileConvertedToBase64;
@@ -26,7 +26,7 @@ class WarpCurrentUserData {
 
       final _did = await _warp.createUser(
         username: newUser.username,
-        password: password,
+        passphrase: passphrase,
         messageStatus: newUser.statusMessage ?? '',
         base64Image: _imageFileConvertedToBase64,
       );

--- a/lib/auth/data/repositories/authentication.repository.dart
+++ b/lib/auth/data/repositories/authentication.repository.dart
@@ -4,7 +4,7 @@ import 'package:uplink/utils/services/services_export.dart';
 abstract class IAuthenticationRepository {
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? passphrase,
+    required String passphrase,
   });
 
   Future<void> savePinValue({required String pinValue, required bool storePin});

--- a/lib/auth/data/repositories/authentication.repository.dart
+++ b/lib/auth/data/repositories/authentication.repository.dart
@@ -4,7 +4,7 @@ import 'package:uplink/utils/services/services_export.dart';
 abstract class IAuthenticationRepository {
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? password,
+    required String? passphrase,
   });
 
   Future<void> savePinValue({required String pinValue, required bool storePin});

--- a/lib/auth/data/repositories/authentication_impl.repository.dart
+++ b/lib/auth/data/repositories/authentication_impl.repository.dart
@@ -18,13 +18,13 @@ class AuthenticationRepositoryImpl implements IAuthenticationRepository {
   @override
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? password,
+    required String? passphrase,
   }) async {
-    log('createCurrentUser password $password');
+    log('createCurrentUser passphrase $passphrase');
     try {
       final _newUser = await _remoteDatasource.createCurrentUser(
         newUser: newUser,
-        password: password,
+        passphrase: passphrase,
       );
       return _newUser;
     } catch (error) {

--- a/lib/auth/data/repositories/authentication_impl.repository.dart
+++ b/lib/auth/data/repositories/authentication_impl.repository.dart
@@ -18,7 +18,7 @@ class AuthenticationRepositoryImpl implements IAuthenticationRepository {
   @override
   Future<CurrentUser> createCurrentUser({
     required CurrentUser newUser,
-    required String? passphrase,
+    required String passphrase,
   }) async {
     log('createCurrentUser passphrase $passphrase');
     try {

--- a/lib/auth/presentation/controller/auth_bloc.dart
+++ b/lib/auth/presentation/controller/auth_bloc.dart
@@ -22,7 +22,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         emit(AuthLoadInProgress());
         final _currentUser = await _repository.createCurrentUser(
           newUser: event.currentUser,
-          password: event.password,
+          passphrase: event.passphrase,
         );
         log('_currentUser is created: ${_currentUser.did}');
         _currentUserController.add(

--- a/lib/auth/presentation/controller/auth_bloc.dart
+++ b/lib/auth/presentation/controller/auth_bloc.dart
@@ -24,6 +24,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           newUser: event.currentUser,
           passphrase: event.passphrase,
         );
+        log('sign up with passphrase: ${event.passphrase}');
         log('_currentUser is created: ${_currentUser.did}');
         _currentUserController.add(
           GetCurrentUserInfo(currentUser: _currentUser),

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -11,7 +11,8 @@ class AuthSignUp extends AuthEvent {
   // TODO(passphrase): All the passphrase are null right now
   AuthSignUp({
     required this.currentUser,
-  }) : passphrase = null;
+    required this.passphrase,
+  });
   final CurrentUser currentUser;
   final String? passphrase;
   @override

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -8,12 +8,12 @@ abstract class AuthEvent {
 class AuthStarted extends AuthEvent {}
 
 class AuthSignUp extends AuthEvent {
-  // TODO(password): All the password are null right now
+  // TODO(passphrase): All the passphrase are null right now
   AuthSignUp({
     required this.currentUser,
-  }) : password = null;
+  }) : passphrase = null;
   final CurrentUser currentUser;
-  final String? password;
+  final String? passphrase;
   @override
   List<Object> get props => [currentUser];
 }

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -13,7 +13,7 @@ class AuthSignUp extends AuthEvent {
     required this.passphrase,
   });
   final CurrentUser currentUser;
-  final String? passphrase;
+  final String passphrase;
   @override
   List<Object> get props => [currentUser];
 }

--- a/lib/auth/presentation/controller/auth_event.dart
+++ b/lib/auth/presentation/controller/auth_event.dart
@@ -8,7 +8,6 @@ abstract class AuthEvent {
 class AuthStarted extends AuthEvent {}
 
 class AuthSignUp extends AuthEvent {
-  // TODO(passphrase): All the passphrase are null right now
   AuthSignUp({
     required this.currentUser,
     required this.passphrase,

--- a/lib/auth/presentation/view/onboard_recovery_seed_page/models/recovery_seed_boxes_part.dart
+++ b/lib/auth/presentation/view/onboard_recovery_seed_page/models/recovery_seed_boxes_part.dart
@@ -1,24 +1,22 @@
 part of '../onboard_recovery_seed_page.dart';
 
-List<String> _seedList = [
-  'art',
-  'bus',
-  'drink',
-  'frost',
-  'hour',
-  'cute',
-  'fly',
-  'frost',
-  'hour',
-  'grow',
-  'join',
-  'paint'
-];
-
-class _RecoverySeedBoxes extends StatelessWidget {
+class _RecoverySeedBoxes extends StatefulWidget {
   const _RecoverySeedBoxes({
     Key? key,
   }) : super(key: key);
+
+  @override
+  State<_RecoverySeedBoxes> createState() => _RecoverySeedBoxesState();
+}
+
+class _RecoverySeedBoxesState extends State<_RecoverySeedBoxes> {
+  final _warpController = GetIt.I.get<WarpBloc>();
+  late List<String> _seedList;
+  @override
+  void initState() {
+    super.initState();
+    _seedList = _warpController.get12RecoverySeeds().split(' ');
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/auth/presentation/view/onboard_recovery_seed_page/onboard_recovery_seed_page.dart
+++ b/lib/auth/presentation/view/onboard_recovery_seed_page/onboard_recovery_seed_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:ui_library/ui_library_export.dart';
 import 'package:uplink/auth/presentation/view/view_export.dart';
 import 'package:uplink/l10n/main_app_strings.dart';
+import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
 
 part 'models/recovery_seed_boxes_part.dart';
 part 'models/screenshot_recovery_seed_boxes_part.dart';

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -10,6 +10,7 @@ import 'package:uplink/auth/presentation/controller/auth_bloc.dart';
 import 'package:uplink/auth/presentation/view/linking_satellites_page.dart';
 import 'package:uplink/l10n/main_app_strings.dart';
 import 'package:uplink/shared/domain/entities/current_user.entity.dart';
+import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
 
 class OnboardCreateProfilePage extends StatefulWidget {
   const OnboardCreateProfilePage({Key? key}) : super(key: key);
@@ -57,6 +58,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
   }
 
   final _authController = GetIt.I.get<AuthBloc>();
+  final _warpController = GetIt.I.get<WarpBloc>();
 
   @override
   Widget build(BuildContext context) {
@@ -194,19 +196,18 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
           _isSigningUp = true;
         });
 
-        signUpAndSetPinData().whenComplete(() {
-          log('signUpAndSetPinData completed');
-          Navigator.pushNamedAndRemoveUntil(
-            context,
-            '/MainBottomNavigationBar',
-            (route) => false,
-          );
-        });
+        signUpAndSetPinData();
+        log('signUpAndSetPinData completed');
+        Navigator.pushNamedAndRemoveUntil(
+          context,
+          '/MainBottomNavigationBar',
+          (route) => false,
+        );
       },
     ).show();
   }
 
-  Future<void> signUpAndSetPinData() async {
+  void signUpAndSetPinData() {
     _authController
       ..add(
         AuthSignUp(
@@ -215,10 +216,13 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
             statusMessage: _messageStatusTextFieldController.text,
             profilePicture: _userPicture,
           ),
+          passphrase: _warpController.recoverySeeds,
         ),
       )
       ..add(
         AuthSetPinData(),
       );
+    //delete the recovery seeds in warp bloc
+    _warpController.deleteRecoverySeeds();
   }
 }

--- a/lib/auth/presentation/view/onboarding_create_profile_page.dart
+++ b/lib/auth/presentation/view/onboarding_create_profile_page.dart
@@ -216,7 +216,7 @@ class _OnboardCreateProfilePageState extends State<OnboardCreateProfilePage> {
             statusMessage: _messageStatusTextFieldController.text,
             profilePicture: _userPicture,
           ),
-          passphrase: _warpController.recoverySeeds,
+          passphrase: _warpController.recoverySeeds!,
         ),
       )
       ..add(

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -9,6 +9,8 @@ import 'package:uplink/l10n/main_app_strings.dart';
 import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
 import 'package:uplink/utils/utils_export.dart';
 
+GlobalKey<UPinState> uPinStateKey = GlobalKey();
+
 class SigninPage extends StatefulWidget {
   const SigninPage({
     Key? key,
@@ -78,12 +80,13 @@ class _SigninPageState extends State<SigninPage> {
                   bloc: _warpController,
                   child: _warpController.multipass == null
                       ? UPin(
-                          key: UniqueKey(),
-                          // TODO(yijing): Get user's pin code length and update the pinLength
-                          pinLength: 4,
+                          key: uPinStateKey,
+                          pinLength: widget.authController.pinValue!.length,
                           rightButtonFn: (pin) {
                             if (pin == widget.authController.pinValue) {
                               _warpController.add(WarpStarted(pin));
+                            } else {
+                              uPinStateKey.currentState?.notifyWrongPin();
                             }
                           },
                         )

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -100,9 +100,14 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
   }
 
   String get12RecoverySeeds() {
-    final _recoverySeeds = warp.mnemonic_standard_phrase();
-    log('recoverySeeds: $_recoverySeeds');
-    return _recoverySeeds;
+    recoverySeeds = warp.mnemonic_standard_phrase();
+    log('get12RecoverySeeds: $recoverySeeds');
+    return recoverySeeds!;
+  }
+
+  void deleteRecoverySeeds() {
+    recoverySeeds = null;
+    log('deleted recovery seeds');
   }
 
   warp.Tesseract? _tesseract;
@@ -112,4 +117,6 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
   String? _tesseractPath;
 
   String? _multipassPath;
+
+  String? recoverySeeds;
 }

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -99,6 +99,12 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
     await _enableTesseract(pin);
   }
 
+  String get12RecoverySeeds() {
+    final _recoverySeeds = warp.mnemonic_standard_phrase();
+    log('recoverySeeds: $_recoverySeeds');
+    return _recoverySeeds;
+  }
+
   warp.Tesseract? _tesseract;
 
   warp_multipass.MultiPass? multipass;

--- a/lib/utils/services/warp/warp_multipass.dart
+++ b/lib/utils/services/warp/warp_multipass.dart
@@ -11,12 +11,12 @@ class WarpMultipass {
   Future<String> createUser({
     required String username,
     required String messageStatus,
-    required String? password,
+    required String? passphrase,
     required String base64Image,
   }) async {
     try {
       final _currentUserDID =
-          _warpBloc.multipass?.createIdentity(username.trim(), password);
+          _warpBloc.multipass?.createIdentity(username.trim(), passphrase);
       changeMessageStatus(messageStatus);
       changeProfilePicture(base64Image);
       return _currentUserDID.toString().replaceAll('did:key:', '');

--- a/lib/utils/services/warp/warp_multipass.dart
+++ b/lib/utils/services/warp/warp_multipass.dart
@@ -11,7 +11,7 @@ class WarpMultipass {
   Future<String> createUser({
     required String username,
     required String messageStatus,
-    required String? passphrase,
+    required String passphrase,
     required String base64Image,
   }) async {
     try {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
1. Get 12 recovery seeds from warp and use it to create an account. 
Every time when user is on the `OnboardRecoverySeedPage`, it will get 12 words(BIP39) from warp, in the mean while, these 12 words will be temporarily saved in WarpBloc until user create an account. 
![image](https://user-images.githubusercontent.com/14248245/190016725-aa078b44-251d-4b3c-8fb7-ff6b35c24c10.png)
After user creating account, these 12 words will be deleted in WarpBloc
![image](https://user-images.githubusercontent.com/14248245/190017413-f24645bd-057e-4bc3-aeee-fff75dd18107.png)
Note: If user choose go to previous page and back to `OnboardRecoverySeedPage` again, the 12 words will be changed. The user will sign up with the latest 12 words which they received.

https://user-images.githubusercontent.com/14248245/190018161-571c38f2-37fe-4154-bdc3-89ab5591e530.mov

2. Update the pin length in `SigninPage` and enable the wrong pin animaiton.

https://user-images.githubusercontent.com/14248245/190018541-e15a6335-1d75-4e19-985c-bcff5a07794d.mov

3. Rename `password` to `passphrase` which represent 12 words recovery seeds
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)

