### PR TITLE
add(ui-library): add UColors.highlight and update the suggested seeds list effect in importing account -UL-186

### DIFF
--- a/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
@@ -51,7 +51,7 @@ class SuggestedSeedsOverlayState extends State<SuggestedSeedsOverlay> {
                   tapedWordIndex = index;
                 }),
                 onTapUp: (details) => Timer(
-                  const Duration(milliseconds: 300),
+                  const Duration(milliseconds: 400),
                   () => widget.onTap(
                     widget.suggestedPassphraseList[index],
                   ),

--- a/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:ui_library/ui_library_export.dart';
 
@@ -33,7 +34,7 @@ class SuggestedSeedsOverlayState extends State<SuggestedSeedsOverlay> {
               final passphrase = widget.suggestedPassphraseList[index];
               var highlight = false;
               if (tapedWordIndex == index) highlight = true;
-              return InkWell(
+              return GestureDetector(
                 child: Container(
                   color: highlight ? UColors.highlight : UColors.foregroundDark,
                   height: 48,
@@ -46,12 +47,15 @@ class SuggestedSeedsOverlayState extends State<SuggestedSeedsOverlay> {
                     textStyle: UTextStyle.BUT1_primaryButton,
                   ),
                 ),
-                onTap: () {
-                  setState(() {
-                    tapedWordIndex = index;
-                    widget.onTap(widget.suggestedPassphraseList[index]);
-                  });
-                },
+                onTapDown: (details) => setState(() {
+                  tapedWordIndex = index;
+                }),
+                onTapUp: (details) => Timer(
+                  const Duration(milliseconds: 300),
+                  () => widget.onTap(
+                    widget.suggestedPassphraseList[index],
+                  ),
+                ),
               );
             },
           ),

--- a/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/suggested_seed_overlay.dart
@@ -35,7 +35,7 @@ class SuggestedSeedsOverlayState extends State<SuggestedSeedsOverlay> {
               if (tapedWordIndex == index) highlight = true;
               return InkWell(
                 child: Container(
-                  color: highlight ? UColors.ctaBlue : UColors.foregroundDark,
+                  color: highlight ? UColors.highlight : UColors.foregroundDark,
                   height: 48,
                   padding: const EdgeInsets.symmetric(
                     horizontal: 16,

--- a/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
@@ -51,7 +51,7 @@ class _TextFieldWithAssociativeSeedsState
         focusNode: focusNode,
         onChanged: (word) {
           //update suggestedPassphraseList to update the suggestion memu
-          searchPassphrass(controller.text.toLowerCase());
+          searchWordInBIP39Dic(word.toLowerCase());
         },
         onSubmitted: (passphrase) {
           final value = passphrase.toLowerCase();
@@ -68,7 +68,7 @@ class _TextFieldWithAssociativeSeedsState
     );
   }
 
-  void searchPassphrass(String query) {
+  void searchWordInBIP39Dic(String query) {
     final _tempDicList = <String>[...bip39Dic];
 
     if (query.isNotEmpty) {

--- a/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
@@ -20,7 +20,7 @@ class TextFieldWithAssociativeSeeds extends StatefulWidget {
 class _TextFieldWithAssociativeSeedsState
     extends State<TextFieldWithAssociativeSeeds> {
   OverlayEntry? overlayEntry;
-  final controller = TextEditingController();
+  final textEditingController = TextEditingController();
   final focusNode = FocusNode();
   List<String> suggestedPassphraseList = [];
   final layerLink = LayerLink();
@@ -34,7 +34,7 @@ class _TextFieldWithAssociativeSeedsState
 
   @override
   void dispose() {
-    controller.dispose();
+    textEditingController.dispose();
     focusNode.dispose();
     overlayEntry?.dispose();
     super.dispose();
@@ -45,7 +45,7 @@ class _TextFieldWithAssociativeSeedsState
     return CompositedTransformTarget(
       link: layerLink,
       child: UTextInput.singleLine(
-        controller: controller,
+        controller: textEditingController,
         hintText: UAppStrings.onboardImportAccountPage_hint,
         autofocus: true,
         focusNode: focusNode,
@@ -57,10 +57,10 @@ class _TextFieldWithAssociativeSeedsState
           final value = passphrase.toLowerCase();
           if (bip39Dic.contains(value)) {
             widget.addInSelectedGridView(passphrase);
-            controller.clear();
+            textEditingController.clear();
             suggestedPassphraseList.clear();
           } else {
-            controller.clear();
+            textEditingController.clear();
             suggestedPassphraseList.clear();
           }
         },
@@ -107,7 +107,7 @@ class _TextFieldWithAssociativeSeedsState
             onTap: (passphrase) {
               widget.addInSelectedGridView(passphrase);
               //delete the texts in text field
-              controller.clear();
+              textEditingController.clear();
               suggestedPassphraseList.clear();
               //close suggested passphrase list
               overlayEntry?.remove();

--- a/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
+++ b/lib/auth/presentation/view/onboard_import_account_page/models/text_field_with_associative_seeds.dart
@@ -104,7 +104,14 @@ class _TextFieldWithAssociativeSeedsState
           offset: const Offset(0, 68),
           child: SuggestedSeedsOverlay(
             suggestedPassphraseList: suggestedPassphraseList,
-            onTap: widget.addInSelectedGridView,
+            onTap: (passphrase) {
+              widget.addInSelectedGridView(passphrase);
+              //delete the texts in text field
+              controller.clear();
+              suggestedPassphraseList.clear();
+              //close suggested passphrase list
+              overlayEntry?.remove();
+            },
           ),
         ),
       ),

--- a/packages/ui_library/lib/core/const/u_colors.dart
+++ b/packages/ui_library/lib/core/const/u_colors.dart
@@ -58,4 +58,7 @@ class UColors {
 
   /// FF38384C
   static const loadLight = Color(0xFF38384C);
+
+  /// FF151A26
+  static const highlight = Color(0xFF151A26);
 }

--- a/packages/ui_library/lib/widgets/buttons/u_drop_down_menu/u_drop_down_menu.dart
+++ b/packages/ui_library/lib/widgets/buttons/u_drop_down_menu/u_drop_down_menu.dart
@@ -72,7 +72,7 @@ class UDropDownMenuState extends State<UDropDownMenu> {
                 ))
             .toList(),
         value: selectedValue ??= widget.items.first,
-        selectedItemHighlightColor: UColors.ctaBlue,
+        selectedItemHighlightColor: UColors.highlight,
         onChanged: (value) {
           setState(() {
             selectedValue = value as String;


### PR DESCRIPTION
## Description
1. Add a UColors.highlight in the UI Library. It will be used in most selected/highlight place.

2. Update the privacy setting list with new highlight color
![image](https://user-images.githubusercontent.com/14248245/190445691-41964d05-ffca-408b-973b-909837c9c3d6.png)

3. Update the the suggested seeds list effect in importing account.
After user tap the word in the suggested seeds list, the selected word will be highlighted, then the word will be added in the import list below, the  suggested seeds list will be closed, the texts in the textfield will be deleted. 
In order to let the user is able to see the highlight color after tapping, I add a 400 delay before the actions afterwards(add words in the import list and close the suggested words list). 
In the video, the first three words are selected by tapping so you can see that highlight color in the list, then the rest two words are typed in full by click the 'check' button in the key board, so there is no highlight color shows in the list.

https://user-images.githubusercontent.com/14248245/190474999-3955ab89-61c4-4915-b005-50a41963798a.mp4




<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
