### PR TITLE
fix(WarpBloc): fix globalKey error

### DIFF
--- a/lib/app/view/main_app.dart
+++ b/lib/app/view/main_app.dart
@@ -92,7 +92,7 @@ Widget _buildEntryPage(
     return BlocBuilder<WarpBloc, WarpState>(
       bloc: _warpController,
       builder: (context, state) {
-        if (state is WarpLoadSuccess) {
+        if (state is WarpLoadSuccess || state is RaygunLoadSuccess) {
           return const MainBottomNavigationBar();
         }
         return ScaffoldCenterPage(

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -7,7 +7,6 @@ import 'package:ui_library/ui_library_export.dart';
 import 'package:uplink/auth/presentation/controller/auth_bloc.dart';
 import 'package:uplink/l10n/main_app_strings.dart';
 import 'package:uplink/utils/services/warp/controller/warp_bloc.dart';
-import 'package:uplink/utils/utils_export.dart';
 
 GlobalKey<UPinState> uPinStateKey = GlobalKey();
 

--- a/lib/auth/presentation/view/signin_page.dart
+++ b/lib/auth/presentation/view/signin_page.dart
@@ -100,10 +100,9 @@ class _SigninPageState extends State<SigninPage> {
                         ),
                   listener: (context, state) {
                     if (state is WarpLoadSuccess) {
-                      Navigator.of(context).pushAndRemoveUntil(
-                        MaterialPageRoute<void>(
-                          builder: (context) => const MainBottomNavigationBar(),
-                        ),
+                      Navigator.pushNamedAndRemoveUntil(
+                        context,
+                        '/MainBottomNavigationBar',
                         (route) => false,
                       );
                     }

--- a/lib/utils/services/warp/controller/warp_bloc.dart
+++ b/lib/utils/services/warp/controller/warp_bloc.dart
@@ -72,16 +72,16 @@ class WarpBloc extends Bloc<WarpEvent, WarpState> {
 
     on<RaygunStarted>((event, emit) {
       try {
-        emit(WarpLoadInProgress());
+        emit(RaygunLoadInProgress());
 
         raygun = rg_ipfs.raygun_ipfs_persistent(
           multipass!,
           _raygunPath!,
         );
 
-        emit(WarpLoadSuccess());
+        emit(RaygunLoadSuccess());
       } catch (error) {
-        emit(WarpLoadFailure());
+        emit(RaygunLoadFailure());
         addError(error);
       }
     });

--- a/lib/utils/services/warp/controller/warp_state.dart
+++ b/lib/utils/services/warp/controller/warp_state.dart
@@ -24,3 +24,18 @@ class WarpLoadFailure extends WarpState {
   @override
   List<Object?> get props => [];
 }
+
+class RaygunLoadInProgress extends WarpState {
+  @override
+  List<Object?> get props => [];
+}
+
+class RaygunLoadSuccess extends WarpState {
+  @override
+  List<Object?> get props => [];
+}
+
+class RaygunLoadFailure extends WarpState {
+  @override
+  List<Object?> get props => [];
+}


### PR DESCRIPTION
## Description
fix #110 
**Issue**
When user go into the main app through sign in page(enter pin), it occurs a duplicate global error and a WarpBloc error as the above issue shown. 

**Reason**
In the previous code, when raygun initialized, it emits the same state as WarpLoad. For example, in the sign in page,
![image](https://user-images.githubusercontent.com/14248245/191657215-01c8e5fc-270f-4c76-8925-4801d475cae6.png)
when state is WarpLoadSuccess, it navigates to the `MainBottomNavigationBar`, but inside `MainBottomNavigationBar`, raygun initial process cause the WarpLoad in loading state again and emit WarpLoadSuccess after it. so it rebuilds the same `MainBottomNavigationBar` which we don't want it.

**Solution**
I separated WarpLoad state and RaygunLoad state, so basically, after `WarpLoadSuccess`, the `MainBottomNavigationBar` will make WarpBloc state become `RaygunLoadSuccess`

For the case when user saved pin in the app, when WarpBloc is in  `WarpLoadSuccess` or 'RaygunLoadSuccess', it will go to `MainBottomNavigationBar`

This solution has solved these errors when user log in the app(with pin and without pin), but it could be improved by refactoring the auth navigation flow in the future. 
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

