### PR TITLE
test(appium): adding more disk size to emulator

### DIFF
--- a/.github/workflows/appium-android.yml
+++ b/.github/workflows/appium-android.yml
@@ -44,6 +44,7 @@ jobs:
         api-level: ${{ matrix.api-level }}
         avd-name: android-appium
         arch: x86_64
+        disk-size: 4G
         working-directory: appium-tests 
         script: |
           npm run android.ci


### PR DESCRIPTION
## Description
- Increasing disk size for emulator running on GH action for appium android to avoid failures on execution
- To do this, added the disk-size option and set it as 4GB in step for Start Emulator and Run Tests

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🧪 Tests
- [X] 🗑️ Chore
