### PR TITLE
chore(appium): increase memory on GH action

### DIFF
--- a/.github/workflows/appium-android.yml
+++ b/.github/workflows/appium-android.yml
@@ -44,20 +44,20 @@ jobs:
         api-level: ${{ matrix.api-level }}
         avd-name: android-appium
         arch: x86_64
-        disk-size: 4G
+        disk-size: 8G
         working-directory: appium-tests 
         script: |
           npm run android.ci
     
     - name: Upload Screenshots if tests failed 📷
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: appium-screenshots
         path: appium-tests/test-results/android
 
     - name: Upload Appium Log if tests failed 📷
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: appium-log


### PR DESCRIPTION
## Description
- Increasing disk size on reactive circus android emulator for Appium GH action on Android
- Updating the actions of upload artifact to v3

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🧪 Tests
- [X] 🗑️ Chore
